### PR TITLE
Security: harden local crawl (SSRF/TLS) + caching robustness

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -28,10 +28,12 @@ ANTHROPIC_API_KEY=YOUR_ANTHROPIC_API_KEY
 # Examples:
 # - "my-metac-bot (you@example.com)"
 # - "metaculus-bot revenue-prefetch (contact: you@example.com)"
-# If SEC_USER_AGENT is not set, the bot will try to derive a reasonable User-Agent from git/GitHub env vars.
+# If SEC_USER_AGENT is not set, the bot will derive a reasonable User-Agent from repo metadata and (optionally)
+# SEC_CONTACT_EMAIL. It will NOT use your local git-config email unless you explicitly opt in.
 # Optional: set SEC_CONTACT_EMAIL to provide contact info without writing a full UA string.
 SEC_USER_AGENT=YOUR_SEC_USER_AGENT
 SEC_CONTACT_EMAIL=
+BOT_ALLOW_GIT_EMAIL_FOR_SEC_USER_AGENT=false
 
 # Optional: Nasdaq API user agent (defaults to a browser-like UA; some endpoints block bot-looking UAs)
 # Example: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
@@ -139,3 +141,9 @@ BOT_LOCAL_CRAWL_TOTAL_CHAR_BUDGET=20000
 BOT_LOCAL_CRAWL_PER_URL_CHAR_BUDGET=4000
 BOT_LOCAL_CRAWL_BLOCKED_RESOURCE_TYPES=image,font,media
 BOT_LOCAL_CRAWL_USER_AGENT=
+# Security/safety defaults (recommended):
+# - Disallow crawling private/loopback/link-local hosts (SSRF protection)
+# - Enforce TLS validation (do not ignore HTTPS errors)
+BOT_LOCAL_CRAWL_ALLOW_PRIVATE_HOSTS=false
+BOT_LOCAL_CRAWL_IGNORE_HTTPS_ERRORS=false
+BOT_LOCAL_CRAWL_RESOLVE_DNS=true

--- a/poetry.lock
+++ b/poetry.lock
@@ -5222,4 +5222,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1c48692ee4c8338b554702c6f72300ea09355739e9652984002702accd343a8a"
+content-hash = "9e554f3b03deec099f285578360fd7dfe875359c53e0c9dd615698ec19225855"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ asknews = "^0.13.0"
 numpy = "^2.3.0"
 openai = "^2.0.0"
 python-dotenv = "^1.0.1"
+pydantic = ">=2.0.0,<3.0.0"
 forecasting-tools = "^0.2.80"
 
 [tool.poetry.group.web.dependencies]

--- a/tests/test_local_web_crawl_security.py
+++ b/tests/test_local_web_crawl_security.py
@@ -1,0 +1,30 @@
+import asyncio
+import unittest
+
+from local_web_crawl import LocalCrawlLimits, PlaywrightWebPageParser
+
+
+class TestLocalCrawlUrlSafety(unittest.TestCase):
+    def test_blocks_private_and_local_hosts_by_default(self) -> None:
+        limits = LocalCrawlLimits(resolve_dns=False)
+        parser = PlaywrightWebPageParser(limits=limits)
+
+        self.assertFalse(asyncio.run(parser.is_url_safe_for_crawl("http://127.0.0.1/")))
+        self.assertFalse(asyncio.run(parser.is_url_safe_for_crawl("http://localhost/")))
+        self.assertFalse(asyncio.run(parser.is_url_safe_for_crawl("http://10.0.0.1/")))
+        self.assertFalse(
+            asyncio.run(parser.is_url_safe_for_crawl("http://169.254.169.254/"))
+        )
+
+    def test_allows_private_hosts_when_enabled(self) -> None:
+        limits = LocalCrawlLimits(resolve_dns=False, allow_private_hosts=True)
+        parser = PlaywrightWebPageParser(limits=limits)
+        self.assertTrue(asyncio.run(parser.is_url_safe_for_crawl("http://127.0.0.1/")))
+        self.assertTrue(asyncio.run(parser.is_url_safe_for_crawl("http://localhost/")))
+
+    def test_blocks_non_http_schemes(self) -> None:
+        limits = LocalCrawlLimits(resolve_dns=False)
+        parser = PlaywrightWebPageParser(limits=limits)
+        self.assertFalse(asyncio.run(parser.is_url_safe_for_crawl("file:///etc/passwd")))
+        self.assertFalse(asyncio.run(parser.is_url_safe_for_crawl("javascript:alert(1)")))
+


### PR DESCRIPTION
Implements #5.

- SSRF protection: block unsafe hosts/schemes for local crawl, including redirects/subrequests.
- TLS: `ignore_https_errors` defaults to false (configurable via env).
- Prompt safety: do not leak raw exception messages into LLM context; add prompt-injection guardrail.
- Robustness: cached local-crawl/tool-router tasks now fail safe instead of propagating.
- Dependency hygiene: add `pydantic` as a direct dependency.
- Tests: add URL safety unit tests.