### PR TITLE
Follow-up: incorporate Copilot review feedback

### DIFF
--- a/.github/workflows/run_bot_on_tournament.yaml
+++ b/.github/workflows/run_bot_on_tournament.yaml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   forecast_job:
     runs-on: ubuntu-latest # determines the machine that will run the job - keep as is
-    timeout-minutes: 70
+    timeout-minutes: 100
     environment: "metaculus bot"
     steps: # sets up the steps that will be run in order
       # setup repository with all necessary dependencies - keep as is


### PR DESCRIPTION
Follow-up to #15.

- Add `reset_smart_searcher_circuit_breaker()` to make SmartSearcher/Exa circuit breaker reset explicit when reusing a bot instance.
- Refactor Exa error handling to avoid counting per-candidate and make the “break on Exa errors” behavior clearer.
- Increase job `timeout-minutes` to 100 so later step timeouts are meaningful even after dependency install overhead.