### PR TITLE
Meta: don\u0027t auto-merge PRs from Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## PR / Merge policy (IMPORTANT)
 - Default behavior: create a branch + open a PR, **do not merge**.
-- Only merge to `main` when the user explicitly asks in the current conversation turn (e.g. “merge/合并到 main/帮我 merge”).
+- Only merge to the repository's default branch (currently `main`) when the user explicitly asks to merge in their message in this conversation (e.g. `merge`, `合并到 main`, `帮我 merge`).
 - If the user asks for a PR but does not explicitly ask to merge, leave the PR open and request confirmation before merging.
-- Do not push directly to `main` unless explicitly requested.
+- Do not push directly to the default branch (currently `main`) unless explicitly requested.
 
 ## Secrets
 - Never print or paste any tokens/keys/secrets in responses or logs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Codex Agent Instructions (metaculus-bot)
+
+## PR / Merge policy (IMPORTANT)
+- Default behavior: create a branch + open a PR, **do not merge**.
+- Only merge to `main` when the user explicitly asks in the current conversation turn (e.g. “merge/合并到 main/帮我 merge”).
+- If the user asks for a PR but does not explicitly ask to merge, leave the PR open and request confirmation before merging.
+- Do not push directly to `main` unless explicitly requested.
+
+## Secrets
+- Never print or paste any tokens/keys/secrets in responses or logs.


### PR DESCRIPTION
Add repo-level agent instructions so Codex will not automatically merge PRs to `main` unless explicitly requested in the current conversation.

Rationale
- Prevent accidental merges.
- Keep PR review/approval in the user loop.