### PR TITLE
Tune scheduled workflow timeouts for 30-min cadence

### DIFF
--- a/.github/workflows/run_bot_on_tournament.yaml
+++ b/.github/workflows/run_bot_on_tournament.yaml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   forecast_job:
     runs-on: ubuntu-latest # determines the machine that will run the job - keep as is
-    timeout-minutes: 100
+    timeout-minutes: 45
     environment: "metaculus bot"
     steps: # sets up the steps that will be run in order
       # setup repository with all necessary dependencies - keep as is
@@ -79,7 +79,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
-        timeout-minutes: 20
+        timeout-minutes: 15
         run: poetry install --no-interaction --no-root --with web
       - name: Install Playwright Chromium (with deps)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
@@ -87,10 +87,10 @@ jobs:
         run: poetry run playwright install --with-deps chromium
       - name: Ensure Playwright Chromium present
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: poetry run playwright install chromium
       - name: Run bot
-        timeout-minutes: 60
+        timeout-minutes: 40
         run: |
           MANUAL_TOURNAMENT="${{ github.event.inputs.tournament }}"
           RESEARCHER="${{ github.event.inputs.researcher }}"
@@ -108,7 +108,7 @@ jobs:
           export SMART_SEARCHER_NUM_SEARCHES
           export SMART_SEARCHER_NUM_SITES_PER_SEARCH
           export SMART_SEARCHER_USE_ADVANCED_FILTERS
-          TOURNAMENT_TIMEOUT_MINUTES="${BOT_TOURNAMENT_TIMEOUT_MINUTES:-30}"
+          TOURNAMENT_TIMEOUT_MINUTES="${BOT_TOURNAMENT_TIMEOUT_MINUTES:-15}"
 
           # Build tournament list
           # If manual input provided, only run that tournament

--- a/.github/workflows/run_bot_on_tournament.yaml
+++ b/.github/workflows/run_bot_on_tournament.yaml
@@ -79,18 +79,18 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
-        timeout-minutes: 15
+        timeout-minutes: 5
         run: poetry install --no-interaction --no-root --with web
       - name: Install Playwright Chromium (with deps)
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        timeout-minutes: 15
+        timeout-minutes: 5
         run: poetry run playwright install --with-deps chromium
       - name: Ensure Playwright Chromium present
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        timeout-minutes: 5
+        timeout-minutes: 2
         run: poetry run playwright install chromium
       - name: Run bot
-        timeout-minutes: 40
+        timeout-minutes: 35
         run: |
           MANUAL_TOURNAMENT="${{ github.event.inputs.tournament }}"
           RESEARCHER="${{ github.event.inputs.researcher }}"


### PR DESCRIPTION
Fixes #19.

Rationale
- Recent successful runs are typically ~1–10 minutes, but the workflow is scheduled every 30 minutes.
- The previous `timeout-minutes: 100` leaves too much room for rare hangs to burn Actions minutes.

Changes (`.github/workflows/run_bot_on_tournament.yaml`)
- Job timeout: 100m -> 45m
- `poetry install` step: 20m -> 15m
- `Ensure Playwright Chromium present` step: 10m -> 5m
- `Run bot` step: 60m -> 40m
- Per-tournament `timeout` default: 30m -> 15m (still overrideable via repo var `BOT_TOURNAMENT_TIMEOUT_MINUTES`)

Notes
- This PR intentionally does **not** change schedule frequency or concurrency cancellation behavior.