### PR TITLE
Prefer Tavily first (monthly free) then Exa fallback

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,9 +17,12 @@ OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY
 PERPLEXITY_API_KEY=YOUR_PERPLEXITY_API_KEY
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
 EXA_API_KEY=YOUR_EXA_API_KEY
-# Note: If EXA_API_KEY is set and BOT_ENABLE_WEB_SEARCH=true, the template defaults to Exa via SmartSearcher
-# (instead of using BOT_SEARCH_MODEL's *-search-preview browsing model). To force the browsing model, run
-# `python main.py --researcher <model>` or unset EXA_API_KEY.
+# Note: If BOT_ENABLE_WEB_SEARCH=true, the template prefers:
+# - Tavily via TavilySmartSearcher when TAVILY_API_KEY is set (monthly free-tier reset)
+# - Exa via SmartSearcher when TAVILY_API_KEY is not set but EXA_API_KEY is set (often a one-time free credit pool)
+# Otherwise it falls back to BOT_SEARCH_MODEL's *-search-preview browsing model.
+# To force the browsing model, run `python main.py --researcher <model>` or unset TAVILY_API_KEY/EXA_API_KEY.
+TAVILY_API_KEY=YOUR_TAVILY_API_KEY
 ASKNEWS_CLIENT_ID=YOUR_ASKNEWS_CLIENT_ID
 ASKNEWS_SECRET=YOUR_ASKNEWS_SECRET
 ANTHROPIC_API_KEY=YOUR_ANTHROPIC_API_KEY
@@ -186,6 +189,13 @@ SMART_SEARCHER_NUM_SEARCHES=1
 SMART_SEARCHER_NUM_SITES_PER_SEARCH=5
 SMART_SEARCHER_USE_ADVANCED_FILTERS=false
 
+# Optional: Tavily settings (used when TAVILY_API_KEY is set)
+TAVILY_SEARCH_DEPTH=basic
+TAVILY_TOPIC=general
+TAVILY_TIME_RANGE=
+TAVILY_INCLUDE_RAW_CONTENT=false
+TAVILY_TIMEOUT_SECONDS=30
+
 # Optional: Local question-link crawl (Playwright/Chromium)
 # Fetches the Metaculus question page (optional) + all explicit links in the question text fields,
 # renders them locally (supports JS-heavy pages), extracts main content, and feeds that text into the research prompt.
@@ -242,6 +252,11 @@ BOT_WEEKLY_RETRO_MAX_QUESTION_LINKS=30
 BOT_WEEKLY_RETRO_UPDATE_SOURCE_CATALOG=true
 # Override the repo to publish to (defaults to the current repo / GITHUB_REPOSITORY):
 BOT_GITHUB_REPO=
+#
+# GitHub auth (optional; needed if you enable publishing reports/patches back to GitHub):
+# - Preferred in this repo: `GH_TOKEN_MetaculusBot`
+# - Fallbacks: `GH_TOKEN` or `GITHUB_TOKEN` (GitHub Actions usually provides `GITHUB_TOKEN` automatically)
+# Never commit tokens into git.
 
 # Optional: Metaculus comment fetch (used to retrieve the bot's explanation text)
 BOT_RETRO_COMMENT_HTTP_TIMEOUT_SECONDS=30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,11 @@
 ## Secrets
 - Never print or paste any tokens/keys/secrets in responses or logs.
 
+## GitHub auth (for automation)
+- Some modes/scripts may call GitHub APIs (e.g. publish weekly retrospective reports via `github_contents.py`).
+- Token env var precedence: `GH_TOKEN_MetaculusBot` → `GH_TOKEN` → `GITHUB_TOKEN` (see `github_contents.get_github_token()`).
+- On this server, the token is commonly stored in `~/.openclaw/.env` under `GH_TOKEN_MetaculusBot` (do not commit it; do not print it).
+
 ## Commit message convention
 - Include explicit identifiers for both the issue and PR to avoid ambiguity (GitHub uses `#<number>` for both).
 - Format: `<type>: <summary> (issue #<issue>, PR #<pr>)`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ To review newly-resolved questions on a schedule (e.g. weekend), use `--mode wee
 ## Research providers (AskNews / others)
 - AskNews research is optional. If your AskNews plan does not allow API access, runs may fail unless you disable it.
 - Disable research (cheapest/minimal): `poetry run python main.py --mode tournament --tournament climate --no-submit --researcher no_research`
-- Use web search (requires `EXA_API_KEY` or `PERPLEXITY_API_KEY`): `poetry run python main.py --mode tournament --tournament climate --no-submit --researcher smart-searcher/openrouter/openai/gpt-oss-120b:free`
+- Use web search via Tavily (requires `TAVILY_API_KEY`): `poetry run python main.py --mode tournament --tournament climate --no-submit --researcher tavily-searcher/openrouter/openai/gpt-oss-120b:free`
+- Use web search via Exa (requires `EXA_API_KEY`): `poetry run python main.py --mode tournament --tournament climate --no-submit --researcher smart-searcher/openrouter/openai/gpt-oss-120b:free`
 - Optional: tool-router (enabled by default) decides which sources to fetch per question (adds ~1 extra non-search LLM call per question):
   - Local crawl (if enabled) runs first, then free official sources (SEC/Nasdaq), then web search only if needed.
   - Disable with `BOT_ENABLE_TOOL_ROUTER=false`.
@@ -137,6 +138,9 @@ poetry run playwright install chromium
 Running the bot requires various environment variables. If you run the bot locally, the easiest way to set them is to create a file called `.env` in the root directory of the repository (copy the `.env.template`).
 
 Note: `METACULUS_TOKEN` should be the raw token value (no `Token ` / `Bearer ` prefix).
+
+Optional: GitHub token (for publishing reports)
+- Some modes (e.g. weekly retrospective) can publish reports/patches back to GitHub. Provide a token via `GH_TOKEN_MetaculusBot` (or `GH_TOKEN` / `GITHUB_TOKEN`) and optionally set `BOT_GITHUB_REPO`.
 
 ### Running the bot
 

--- a/bot/metaculus_bot.py
+++ b/bot/metaculus_bot.py
@@ -25,6 +25,7 @@ from typing import Sequence
 from bot.env import env_bool as _env_bool, env_float as _env_float, env_int as _env_int
 from bot.local_crawl_support import LocalCrawlSupportMixin
 from bot.smart_searcher_circuit import SmartSearcherCircuitMixin
+from bot.tavily_searcher import TavilySmartSearcher
 from bot.tool_router import ToolRouterMixin, ToolRouterPlan
 
 import requests
@@ -959,8 +960,16 @@ class MetaculusBot(
             merged_base_kwargs = {**base_llm_kwargs, **extra_kwargs}
 
             researcher: str | GeneralLlm
-            if enable_web_search and os.getenv("EXA_API_KEY"):
-                # Prefer Exa + SmartSearcher (no paid "search-preview" models required).
+            if enable_web_search and os.getenv("TAVILY_API_KEY"):
+                # Prefer Tavily first (monthly free-tier reset) + local SmartSearcher-like flow
+                # (no paid "search-preview" models required).
+                researcher = (
+                    "tavily-searcher/kiconnect"
+                    if has_kiconnect
+                    else "tavily-searcher/openrouter/openai/gpt-oss-120b:free"
+                )
+            elif enable_web_search and os.getenv("EXA_API_KEY"):
+                # Fall back to Exa + SmartSearcher (often a one-time free credit pool).
                 researcher = (
                     "smart-searcher/kiconnect"
                     if has_kiconnect
@@ -2456,6 +2465,7 @@ class MetaculusBot(
                 "search-preview" in researcher_model_name_lower
                 or researcher_model_name_lower.startswith("perplexity/")
                 or researcher_model_name_lower.startswith("smart-searcher/")
+                or researcher_model_name_lower.startswith("tavily-searcher/")
                 or researcher_model_name_lower.startswith("asknews/")
             )
             use_web_search_for_call = bool(tool_plan.use_web_search)
@@ -2638,52 +2648,382 @@ class MetaculusBot(
                             f"AskNews research failed, continuing without it: {error_text}"
                         )
                     research = ""
+            elif isinstance(researcher, str) and researcher.startswith("tavily-searcher"):
+                fallback_research = "\n\n".join(
+                    [part for part in [local_crawl_block, official_block] if part]
+                ).strip()
+                model_name = researcher.removeprefix("tavily-searcher/")
+                model_name_lower = model_name.strip().lower()
+                if model_name_lower == "kiconnect" or model_name_lower.startswith(
+                    "kiconnect/"
+                ):
+                    kiconnect_api_url = os.getenv("KICONNECT_API_URL", "").strip()
+                    kiconnect_api_key = os.getenv("KICONNECT_API_KEY", "").strip()
+                    kiconnect_model = os.getenv("KICONNECT_MODEL", "").strip()
+                    if not (kiconnect_api_url and kiconnect_api_key and kiconnect_model):
+                        raise ValueError(
+                            "tavily-searcher/kiconnect requested but KICONNECT_API_URL/KICONNECT_API_KEY/KICONNECT_MODEL are not all set."
+                        )
+                    ssl_verify = self._parse_ssl_verify_env("KICONNECT_SSL_VERIFY")
+                    search_llm_kwargs: dict = {}
+                    if ssl_verify is not None:
+                        search_llm_kwargs["ssl_verify"] = ssl_verify
+                    override_model = None
+                    if "/" in model_name:
+                        _, override_model = model_name.split("/", 1)
+                        override_model = override_model.strip() or None
+                    search_llm = GeneralLlm(
+                        model=f"openai/{override_model or kiconnect_model}",
+                        temperature=0,
+                        base_url=kiconnect_api_url,
+                        api_key=kiconnect_api_key,
+                        custom_llm_provider="openai",
+                        **search_llm_kwargs,
+                    )
+                    model_name = search_llm
+
+                try:
+                    num_searches_to_run = int(os.getenv("SMART_SEARCHER_NUM_SEARCHES", "2"))
+                except Exception:
+                    num_searches_to_run = 2
+                try:
+                    num_sites_per_search = int(
+                        os.getenv("SMART_SEARCHER_NUM_SITES_PER_SEARCH", "10")
+                    )
+                except Exception:
+                    num_sites_per_search = 10
+                use_advanced_filters = (
+                    os.getenv("SMART_SEARCHER_USE_ADVANCED_FILTERS", "")
+                    .strip()
+                    .lower()
+                    in {"1", "true", "yes", "y"}
+                )
+
+                disabled_reason = getattr(self, "_tavily_searcher_disabled_reason", None)
+                if disabled_reason:
+                    exa_key = os.getenv("EXA_API_KEY", "").strip()
+                    exa_disabled = getattr(self, "_smart_searcher_disabled_reason", None)
+                    if exa_key and not exa_disabled:
+                        logger.warning(
+                            "TavilySearcher disabled (%s). Falling back to Exa for %s.",
+                            disabled_reason,
+                            question.page_url,
+                        )
+                        try:
+                            research = await SmartSearcher(
+                                model=model_name,
+                                temperature=0,
+                                num_searches_to_run=max(1, num_searches_to_run),
+                                num_sites_per_search=max(1, num_sites_per_search),
+                                use_advanced_filters=use_advanced_filters,
+                            ).invoke(prompt)
+                            self._smart_searcher_consecutive_failures = 0
+                        except Exception as e:
+                            logger.warning(
+                                "Exa fallback failed; continuing without web search for %s. Error: %s",
+                                question.page_url,
+                                repr(e)[:300],
+                            )
+                            research = fallback_research
+                    else:
+                        logger.warning(
+                            "TavilySearcher disabled (%s). Continuing without web search for %s.",
+                            disabled_reason,
+                            question.page_url,
+                        )
+                        research = fallback_research
+                else:
+                    tavily_depth = os.getenv("TAVILY_SEARCH_DEPTH", "basic").strip()
+                    tavily_topic = os.getenv("TAVILY_TOPIC", "general").strip()
+                    tavily_time_range = os.getenv("TAVILY_TIME_RANGE", "").strip() or None
+                    tavily_include_raw = _env_bool("TAVILY_INCLUDE_RAW_CONTENT", False)
+                    tavily_timeout = float(_env_float("TAVILY_TIMEOUT_SECONDS", 30.0))
+
+                    max_provider_failures = _env_int(
+                        "BOT_SMART_SEARCHER_MAX_CONSECUTIVE_FAILURES", 2
+                    )
+
+                    candidate_models: list[str | GeneralLlm] = [model_name]
+                    if isinstance(model_name, GeneralLlm):
+                        candidate_models.extend(
+                            self._make_kiconnect_fallback_llms_from_llm(model_name)
+                        )
+                        fallback_search_model_name = self._fallback_model_name_for(
+                            model_name.model
+                        )
+                        if (
+                            fallback_search_model_name
+                            and fallback_search_model_name != model_name.model
+                        ):
+                            candidate_models.append(
+                                GeneralLlm(
+                                    model=fallback_search_model_name, temperature=0
+                                )
+                            )
+
+                    seen: set[str] = set()
+                    deduped_models: list[str | GeneralLlm] = []
+                    for candidate in candidate_models:
+                        candidate_name = GeneralLlm.to_model_name(candidate)
+                        if candidate_name in seen:
+                            continue
+                        seen.add(candidate_name)
+                        deduped_models.append(candidate)
+
+                    last_error: BaseException | None = None
+                    provider_error: BaseException | None = None
+                    for idx, candidate in enumerate(deduped_models, start=1):
+                        searcher = TavilySmartSearcher(
+                            model=candidate,
+                            temperature=0,
+                            num_searches_to_run=max(1, num_searches_to_run),
+                            num_sites_per_search=max(1, num_sites_per_search),
+                            search_depth=tavily_depth,
+                            topic=tavily_topic,
+                            time_range=tavily_time_range,
+                            include_raw_content=tavily_include_raw,
+                            timeout_seconds=tavily_timeout,
+                        )
+                        try:
+                            research = await searcher.invoke(prompt)
+                            self._tavily_searcher_consecutive_failures = 0
+                            break
+                        except BaseException as e:
+                            last_error = e
+                            if self._is_probably_tavily_error(e):
+                                provider_error = e
+                                break
+                            if not self._is_transient_provider_error(e):
+                                raise
+                            if idx >= len(deduped_models):
+                                raise
+                            logger.warning(
+                                "TavilySearcher (%s): search model '%s' failed; retrying with fallback search model #%s '%s'. Error: %s",
+                                question.page_url,
+                                GeneralLlm.to_model_name(candidate),
+                                idx,
+                                GeneralLlm.to_model_name(deduped_models[idx]),
+                                e,
+                            )
+                    else:
+                        raise last_error if last_error is not None else RuntimeError(
+                            "TavilySearcher failed without an exception"
+                        )
+
+                    if provider_error is not None:
+                        if self._is_tavily_nonrecoverable_error(provider_error):
+                            reason = f"nonrecoverable Tavily error: {provider_error.__class__.__name__}"
+                            self._tavily_searcher_disabled_reason = reason
+                            if tool_trace is not None:
+                                tool_trace_record_value(
+                                    tool_trace,
+                                    key="tavily_searcher_disabled_reason",
+                                    value=reason,
+                                )
+                            logger.warning(
+                                "TavilySearcher disabled (%s). Continuing without web search for %s. Error: %s",
+                                reason,
+                                question.page_url,
+                                repr(provider_error)[:300],
+                            )
+                        else:
+                            self._tavily_searcher_consecutive_failures += 1
+                            if (
+                                max_provider_failures > 0
+                                and self._tavily_searcher_consecutive_failures
+                                >= max_provider_failures
+                            ):
+                                reason = f"Tavily failures >= {max_provider_failures}"
+                                self._tavily_searcher_disabled_reason = reason
+                                if tool_trace is not None:
+                                    tool_trace_record_value(
+                                        tool_trace,
+                                        key="tavily_searcher_disabled_reason",
+                                        value=reason,
+                                    )
+                                logger.warning(
+                                    "TavilySearcher disabled (%s) after repeated Tavily failures. Continuing without web search for %s. Error: %s",
+                                    reason,
+                                    question.page_url,
+                                    repr(provider_error)[:300],
+                                )
+                            else:
+                                logger.warning(
+                                    "TavilySearcher error for %s (consecutive failures=%s). Continuing without web search for this question. Error: %s",
+                                    question.page_url,
+                                    self._tavily_searcher_consecutive_failures,
+                                    repr(provider_error)[:300],
+                                )
+                        exa_key = os.getenv("EXA_API_KEY", "").strip()
+                        exa_disabled = getattr(self, "_smart_searcher_disabled_reason", None)
+                        if exa_key and not exa_disabled:
+                            logger.warning(
+                                "Falling back to Exa for %s after Tavily failure.",
+                                question.page_url,
+                            )
+                            try:
+                                research = await SmartSearcher(
+                                    model=model_name,
+                                    temperature=0,
+                                    num_searches_to_run=max(1, num_searches_to_run),
+                                    num_sites_per_search=max(1, num_sites_per_search),
+                                    use_advanced_filters=use_advanced_filters,
+                                ).invoke(prompt)
+                                self._smart_searcher_consecutive_failures = 0
+                            except BaseException as e:
+                                if self._is_probably_exa_error(e):
+                                    if self._is_exa_nonrecoverable_error(e):
+                                        reason = f"nonrecoverable Exa error: {e.__class__.__name__}"
+                                        self._smart_searcher_disabled_reason = reason
+                                        if tool_trace is not None:
+                                            tool_trace_record_value(
+                                                tool_trace,
+                                                key="smart_searcher_disabled_reason",
+                                                value=reason,
+                                            )
+                                        logger.warning(
+                                            "SmartSearcher disabled (%s). Continuing without web search for %s. Error: %s",
+                                            reason,
+                                            question.page_url,
+                                            repr(e)[:300],
+                                        )
+                                    else:
+                                        max_exa_failures = _env_int(
+                                            "BOT_SMART_SEARCHER_MAX_CONSECUTIVE_FAILURES", 2
+                                        )
+                                        self._smart_searcher_consecutive_failures += 1
+                                        if (
+                                            max_exa_failures > 0
+                                            and self._smart_searcher_consecutive_failures
+                                            >= max_exa_failures
+                                        ):
+                                            reason = f"Exa failures >= {max_exa_failures}"
+                                            self._smart_searcher_disabled_reason = reason
+                                            if tool_trace is not None:
+                                                tool_trace_record_value(
+                                                    tool_trace,
+                                                    key="smart_searcher_disabled_reason",
+                                                    value=reason,
+                                                )
+                                            logger.warning(
+                                                "SmartSearcher disabled (%s) after repeated Exa failures. Continuing without web search for %s. Error: %s",
+                                                reason,
+                                                question.page_url,
+                                                repr(e)[:300],
+                                            )
+                                        else:
+                                            logger.warning(
+                                                "SmartSearcher Exa error for %s (consecutive failures=%s). Continuing without web search for this question. Error: %s",
+                                                question.page_url,
+                                                self._smart_searcher_consecutive_failures,
+                                                repr(e)[:300],
+                                            )
+                                else:
+                                    logger.warning(
+                                        "Exa fallback failed; continuing without web search for %s. Error: %s",
+                                        question.page_url,
+                                        repr(e)[:300],
+                                    )
+                                research = fallback_research
+                        else:
+                            research = fallback_research
             elif isinstance(researcher, str) and researcher.startswith("smart-searcher"):
                 fallback_research = "\n\n".join(
                     [part for part in [local_crawl_block, official_block] if part]
                 ).strip()
+                model_name = researcher.removeprefix("smart-searcher/")
+                model_name_lower = model_name.strip().lower()
+                if model_name_lower == "kiconnect" or model_name_lower.startswith(
+                    "kiconnect/"
+                ):
+                    kiconnect_api_url = os.getenv("KICONNECT_API_URL", "").strip()
+                    kiconnect_api_key = os.getenv("KICONNECT_API_KEY", "").strip()
+                    kiconnect_model = os.getenv("KICONNECT_MODEL", "").strip()
+                    if not (kiconnect_api_url and kiconnect_api_key and kiconnect_model):
+                        raise ValueError(
+                            "smart-searcher/kiconnect requested but KICONNECT_API_URL/KICONNECT_API_KEY/KICONNECT_MODEL are not all set."
+                        )
+                    ssl_verify = self._parse_ssl_verify_env("KICONNECT_SSL_VERIFY")
+                    search_llm_kwargs: dict = {}
+                    if ssl_verify is not None:
+                        search_llm_kwargs["ssl_verify"] = ssl_verify
+                    override_model = None
+                    if "/" in model_name:
+                        _, override_model = model_name.split("/", 1)
+                        override_model = override_model.strip() or None
+                    search_llm = GeneralLlm(
+                        model=f"openai/{override_model or kiconnect_model}",
+                        temperature=0,
+                        base_url=kiconnect_api_url,
+                        api_key=kiconnect_api_key,
+                        custom_llm_provider="openai",
+                        **search_llm_kwargs,
+                    )
+                    model_name = search_llm
                 disabled_reason = getattr(self, "_smart_searcher_disabled_reason", None)
                 if disabled_reason:
-                    logger.warning(
-                        "SmartSearcher disabled (%s). Continuing without web search for %s.",
-                        disabled_reason,
-                        question.page_url,
+                    tavily_key = os.getenv("TAVILY_API_KEY", "").strip()
+                    tavily_disabled = getattr(
+                        self, "_tavily_searcher_disabled_reason", None
                     )
-                    research = fallback_research
-                else:
-                    model_name = researcher.removeprefix("smart-searcher/")
-                    model_name_lower = model_name.strip().lower()
-                    if model_name_lower == "kiconnect" or model_name_lower.startswith(
-                        "kiconnect/"
-                    ):
-                        kiconnect_api_url = os.getenv("KICONNECT_API_URL", "").strip()
-                        kiconnect_api_key = os.getenv("KICONNECT_API_KEY", "").strip()
-                        kiconnect_model = os.getenv("KICONNECT_MODEL", "").strip()
-                        if not (
-                            kiconnect_api_url and kiconnect_api_key and kiconnect_model
-                        ):
-                            raise ValueError(
-                                "smart-searcher/kiconnect requested but KICONNECT_API_URL/KICONNECT_API_KEY/KICONNECT_MODEL are not all set."
+                    if tavily_key and not tavily_disabled:
+                        try:
+                            num_searches_to_run = int(
+                                os.getenv("SMART_SEARCHER_NUM_SEARCHES", "2")
                             )
-                        ssl_verify = self._parse_ssl_verify_env("KICONNECT_SSL_VERIFY")
-                        search_llm_kwargs: dict = {}
-                        if ssl_verify is not None:
-                            search_llm_kwargs["ssl_verify"] = ssl_verify
-                        override_model = None
-                        if "/" in model_name:
-                            _, override_model = model_name.split("/", 1)
-                            override_model = override_model.strip() or None
-                        search_llm = GeneralLlm(
-                            model=f"openai/{override_model or kiconnect_model}",
-                            temperature=0,
-                            base_url=kiconnect_api_url,
-                            api_key=kiconnect_api_key,
-                            # Ensure LiteLLM treats unknown model names as OpenAI-compatible
-                            # (important for KICONNECT_MODEL_FALLBACKS like gpt-oss-*).
-                            custom_llm_provider="openai",
-                            **search_llm_kwargs,
+                        except Exception:
+                            num_searches_to_run = 2
+                        try:
+                            num_sites_per_search = int(
+                                os.getenv("SMART_SEARCHER_NUM_SITES_PER_SEARCH", "10")
+                            )
+                        except Exception:
+                            num_sites_per_search = 10
+
+                        tavily_depth = os.getenv("TAVILY_SEARCH_DEPTH", "basic").strip()
+                        tavily_topic = os.getenv("TAVILY_TOPIC", "general").strip()
+                        tavily_time_range = (
+                            os.getenv("TAVILY_TIME_RANGE", "").strip() or None
                         )
-                        model_name = search_llm
+                        tavily_include_raw = _env_bool(
+                            "TAVILY_INCLUDE_RAW_CONTENT", False
+                        )
+                        tavily_timeout = float(
+                            _env_float("TAVILY_TIMEOUT_SECONDS", 30.0)
+                        )
+
+                        logger.warning(
+                            "SmartSearcher disabled (%s). Falling back to Tavily for %s.",
+                            disabled_reason,
+                            question.page_url,
+                        )
+                        try:
+                            research = await TavilySmartSearcher(
+                                model=model_name,
+                                temperature=0,
+                                num_searches_to_run=max(1, num_searches_to_run),
+                                num_sites_per_search=max(1, num_sites_per_search),
+                                search_depth=tavily_depth,
+                                topic=tavily_topic,
+                                time_range=tavily_time_range,
+                                include_raw_content=tavily_include_raw,
+                                timeout_seconds=tavily_timeout,
+                            ).invoke(prompt)
+                        except Exception as e:
+                            logger.warning(
+                                "Tavily fallback failed; continuing without web search for %s. Error: %s",
+                                question.page_url,
+                                repr(e)[:300],
+                            )
+                            research = fallback_research
+                    else:
+                        logger.warning(
+                            "SmartSearcher disabled (%s). Continuing without web search for %s.",
+                            disabled_reason,
+                            question.page_url,
+                        )
+                        research = fallback_research
+                else:
                     try:
                         num_searches_to_run = int(
                             os.getenv("SMART_SEARCHER_NUM_SEARCHES", "2")
@@ -2780,6 +3120,51 @@ class MetaculusBot(
                                 question.page_url,
                                 repr(exa_error)[:300],
                             )
+
+                            tavily_key = os.getenv("TAVILY_API_KEY", "").strip()
+                            tavily_disabled = getattr(
+                                self, "_tavily_searcher_disabled_reason", None
+                            )
+                            if tavily_key and not tavily_disabled:
+                                tavily_depth = os.getenv(
+                                    "TAVILY_SEARCH_DEPTH", "basic"
+                                ).strip()
+                                tavily_topic = os.getenv("TAVILY_TOPIC", "general").strip()
+                                tavily_time_range = (
+                                    os.getenv("TAVILY_TIME_RANGE", "").strip() or None
+                                )
+                                tavily_include_raw = _env_bool(
+                                    "TAVILY_INCLUDE_RAW_CONTENT", False
+                                )
+                                tavily_timeout = float(
+                                    _env_float("TAVILY_TIMEOUT_SECONDS", 30.0)
+                                )
+                                logger.warning(
+                                    "Falling back to Tavily for %s after Exa failure.",
+                                    question.page_url,
+                                )
+                                try:
+                                    research = await TavilySmartSearcher(
+                                        model=candidate,
+                                        temperature=0,
+                                        num_searches_to_run=max(1, num_searches_to_run),
+                                        num_sites_per_search=max(1, num_sites_per_search),
+                                        search_depth=tavily_depth,
+                                        topic=tavily_topic,
+                                        time_range=tavily_time_range,
+                                        include_raw_content=tavily_include_raw,
+                                        timeout_seconds=tavily_timeout,
+                                    ).invoke(prompt)
+                                    self._tavily_searcher_consecutive_failures = 0
+                                except Exception as e:
+                                    logger.warning(
+                                        "Tavily fallback failed; continuing without web search for %s. Error: %s",
+                                        question.page_url,
+                                        repr(e)[:300],
+                                    )
+                                    research = fallback_research
+                            else:
+                                research = fallback_research
                         else:
                             self._smart_searcher_consecutive_failures += 1
                             if (
@@ -2808,7 +3193,7 @@ class MetaculusBot(
                                     self._smart_searcher_consecutive_failures,
                                     repr(exa_error)[:300],
                                 )
-                        research = fallback_research
+                            research = fallback_research
             else:
                 research = await self._invoke_llm_with_transient_fallback(
                     "researcher", prompt, context=f"Research ({question.page_url})"

--- a/bot/metaculus_bot.py
+++ b/bot/metaculus_bot.py
@@ -2827,7 +2827,10 @@ class MetaculusBot(
                                 repr(provider_error)[:300],
                             )
                         else:
-                            self._tavily_searcher_consecutive_failures += 1
+                            self._tavily_searcher_consecutive_failures = (
+                                getattr(self, "_tavily_searcher_consecutive_failures", 0)
+                                + 1
+                            )
                             if (
                                 max_provider_failures > 0
                                 and self._tavily_searcher_consecutive_failures

--- a/bot/smart_searcher_circuit.py
+++ b/bot/smart_searcher_circuit.py
@@ -7,13 +7,15 @@ logger = logging.getLogger(__name__)
 class SmartSearcherCircuitMixin:
     def reset_smart_searcher_circuit_breaker(self) -> None:
         """
-        Reset SmartSearcher/Exa circuit breaker state.
+        Reset SmartSearcher web-search circuit breaker state.
 
         Useful when reusing a single bot instance across multiple tournaments.
         """
 
         self._smart_searcher_disabled_reason = None
         self._smart_searcher_consecutive_failures = 0
+        self._tavily_searcher_disabled_reason = None
+        self._tavily_searcher_consecutive_failures = 0
 
     @staticmethod
     def _is_probably_exa_error(error: BaseException) -> bool:
@@ -36,6 +38,30 @@ class SmartSearcherCircuitMixin:
         if "invalid api key" in error_text or "unauthorized" in error_text or " 401" in error_text:
             return True
         if "payment required" in error_text or "insufficient credits" in error_text or " 402" in error_text:
+            return True
+        if "forbidden" in error_text or " 403" in error_text:
+            return True
+        return False
+
+    @staticmethod
+    def _is_probably_tavily_error(error: BaseException) -> bool:
+        error_text = str(error).lower()
+        if "api.tavily.com" in error_text or "tavily" in error_text:
+            return True
+        if "tavily_api_key" in error_text:
+            return True
+        return False
+
+    @staticmethod
+    def _is_tavily_nonrecoverable_error(error: BaseException) -> bool:
+        error_text = str(error).lower()
+        if "tavily_api_key" in error_text and (
+            "not set" in error_text or "missing" in error_text
+        ):
+            return True
+        if "unauthorized" in error_text or " 401" in error_text:
+            return True
+        if "payment required" in error_text or "insufficient" in error_text or " 402" in error_text:
             return True
         if "forbidden" in error_text or " 403" in error_text:
             return True

--- a/bot/tavily_searcher.py
+++ b/bot/tavily_searcher.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime
+
+import aiohttp
+
+from forecasting_tools import GeneralLlm, clean_indents
+from forecasting_tools.util.misc import fill_in_citations
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TavilySearchResult:
+    query: str
+    title: str | None
+    url: str | None
+    content: str | None
+    raw_content: str | None
+    score: float | None
+
+
+class TavilySearcher:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout_seconds: float = 30,
+        max_concurrency: int = 3,
+        search_depth: str = "basic",
+        topic: str = "general",
+        time_range: str | None = None,
+        include_raw_content: bool = False,
+        include_images: bool = False,
+    ) -> None:
+        self._api_key = (api_key or os.getenv("TAVILY_API_KEY") or "").strip()
+        if not self._api_key:
+            raise ValueError("TAVILY_API_KEY is not set in the environment variables")
+
+        self._timeout = aiohttp.ClientTimeout(total=max(1.0, float(timeout_seconds)))
+        self._sem = asyncio.Semaphore(max(1, int(max_concurrency)))
+
+        self._search_depth = (search_depth or "basic").strip()
+        self._topic = (topic or "general").strip()
+        self._time_range = (time_range or "").strip() or None
+        self._include_raw_content = bool(include_raw_content)
+        self._include_images = bool(include_images)
+
+    async def search(
+        self,
+        *,
+        query: str,
+        max_results: int,
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+    ) -> list[TavilySearchResult]:
+        query = (query or "").strip()
+        if not query:
+            return []
+
+        url = "https://api.tavily.com/search"
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+        payload: dict = {
+            "query": query,
+            "search_depth": self._search_depth,
+            "topic": self._topic,
+            "max_results": max(1, int(max_results)),
+            "include_answer": False,
+            "include_raw_content": self._include_raw_content,
+            "include_images": self._include_images,
+            "include_domains": include_domains or [],
+            "exclude_domains": exclude_domains or [],
+        }
+        if self._time_range:
+            payload["time_range"] = self._time_range
+
+        async with self._sem:
+            async with aiohttp.ClientSession(timeout=self._timeout) as session:
+                async with session.post(url, json=payload, headers=headers) as response:
+                    response.raise_for_status()
+                    data: dict = await response.json()
+
+        results: list[TavilySearchResult] = []
+        for item in data.get("results") or []:
+            if not isinstance(item, dict):
+                continue
+            results.append(
+                TavilySearchResult(
+                    query=query,
+                    title=item.get("title"),
+                    url=item.get("url"),
+                    content=item.get("content"),
+                    raw_content=item.get("raw_content"),
+                    score=item.get("score"),
+                )
+            )
+        return results
+
+
+class TavilySmartSearcher:
+    """
+    SmartSearcher-like research workflow powered by Tavily.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str | GeneralLlm,
+        temperature: float | None = None,
+        num_searches_to_run: int = 1,
+        num_sites_per_search: int = 5,
+        search_depth: str = "basic",
+        topic: str = "general",
+        time_range: str | None = None,
+        include_raw_content: bool = False,
+        per_result_char_budget: int = 1200,
+        total_context_char_budget: int = 12000,
+        timeout_seconds: float = 30,
+    ) -> None:
+        assert temperature is None or 0 <= temperature <= 1
+        self._temperature = temperature
+        self._num_searches_to_run = max(1, int(num_searches_to_run))
+        self._num_sites_per_search = max(1, int(num_sites_per_search))
+        self._per_result_char_budget = max(200, int(per_result_char_budget))
+        self._total_context_char_budget = max(1000, int(total_context_char_budget))
+
+        self._llm = (
+            model
+            if isinstance(model, GeneralLlm)
+            else GeneralLlm(model=model, temperature=temperature)
+        )
+        self._tavily = TavilySearcher(
+            timeout_seconds=timeout_seconds,
+            search_depth=search_depth,
+            topic=topic,
+            time_range=time_range,
+            include_raw_content=include_raw_content,
+        )
+
+    async def invoke(self, prompt: str) -> str:
+        prompt = (prompt or "").strip()
+        if not prompt:
+            raise ValueError("Prompt cannot be empty")
+
+        search_terms = await self._come_up_with_search_queries(prompt)
+        results = await self._search(search_terms)
+        report = await self._compile_report(results, prompt)
+        return self._link_citations(report, results)
+
+    async def _come_up_with_search_queries(self, prompt: str) -> list[str]:
+        prompt = clean_indents(
+            f"""
+            You have been given the following instructions. Instructions are included between <><><><><><><><><><><><> tags.
+
+            <><><><><><><><><><><><>
+            {prompt}
+            <><><><><><><><><><><><>
+
+            Generate {self._num_searches_to_run} web searches that will help you fulfill any questions in the instructions.
+            Make them each target different aspects of the question.
+            Please provide the searches as a JSON list of strings like this:
+            ["search 1", "search 2"]
+            Give no other text than the list of search terms.
+            """
+        )
+        search_terms = await self._llm.invoke_and_return_verified_type(prompt, list[str])
+        cleaned = [(term or "").strip() for term in search_terms if (term or "").strip()]
+        return cleaned[: self._num_searches_to_run]
+
+    async def _search(self, search_terms: list[str]) -> list[TavilySearchResult]:
+        if not search_terms:
+            return []
+
+        batches = await asyncio.gather(
+            *[
+                self._tavily.search(query=term, max_results=self._num_sites_per_search)
+                for term in search_terms
+            ]
+        )
+        flattened = [item for batch in batches for item in batch]
+
+        seen: set[str] = set()
+        deduped: list[TavilySearchResult] = []
+        for item in flattened:
+            url = (item.url or "").strip()
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            deduped.append(item)
+        return deduped
+
+    async def _compile_report(
+        self, results: list[TavilySearchResult], original_instructions: str
+    ) -> str:
+        if not results:
+            return "No search results found for the query."
+
+        context_lines: list[str] = []
+        remaining = self._total_context_char_budget
+        for idx, item in enumerate(results, start=1):
+            url = item.url or "No URL found"
+            title = item.title or "Untitled"
+            body = (item.raw_content or item.content or "").strip()
+            if not body:
+                continue
+            if remaining <= 0:
+                break
+            body = body[: min(len(body), self._per_result_char_budget, remaining)]
+            remaining -= len(body)
+            context_lines.append(
+                f'[{idx}] "{body}". [Source: {url} titled "{title}"]'
+            )
+
+        search_result_context = "\n".join(context_lines).strip()
+        if not search_result_context:
+            return "No usable search results found for the query."
+
+        prompt = clean_indents(
+            f"""
+            Today is {datetime.now().strftime("%Y-%m-%d")}.
+            You have been given the following instructions. Instructions are included between <><><><><><><><><><><><> tags.
+
+            <><><><><><><><><><><><>
+            {original_instructions}
+            <><><><><><><><><><><><>
+
+            After searching the internet, you found the following results. Results are included between <><><><><><><><><><><><> tags.
+            <><><><><><><><><><><><>
+            {search_result_context}
+            <><><><><><><><><><><><>
+
+            Please follow the instructions and use the search results to answer the question. Unless the instructions specifify otherwise, cite your sources inline using [1], [2], etc and use markdown formatting.
+            """
+        )
+        return await self._llm.invoke(prompt)
+
+    @staticmethod
+    def _link_citations(text: str, results: list[TavilySearchResult]) -> str:
+        urls: list[str] = []
+        for item in results:
+            url = (item.url or "").strip()
+            if not url:
+                url = "No URL found"
+            urls.append(url)
+        return fill_in_citations(urls, text, use_citation_brackets=False)

--- a/bot/tavily_searcher.py
+++ b/bot/tavily_searcher.py
@@ -121,8 +121,8 @@ class TavilySmartSearcher:
         total_context_char_budget: int = 12000,
         timeout_seconds: float = 30,
     ) -> None:
-        assert temperature is None or 0 <= temperature <= 1
-        self._temperature = temperature
+        if temperature is not None and not (0 <= temperature <= 1):
+            raise ValueError("temperature must be between 0 and 1")
         self._num_searches_to_run = max(1, int(num_searches_to_run))
         self._num_sites_per_search = max(1, int(num_sites_per_search))
         self._per_result_char_budget = max(200, int(per_result_char_budget))
@@ -233,7 +233,7 @@ class TavilySmartSearcher:
             {search_result_context}
             <><><><><><><><><><><><>
 
-            Please follow the instructions and use the search results to answer the question. Unless the instructions specifify otherwise, cite your sources inline using [1], [2], etc and use markdown formatting.
+            Please follow the instructions and use the search results to answer the question. Unless the instructions specify otherwise, cite your sources inline using [1], [2], etc and use markdown formatting.
             """
         )
         return await self._llm.invoke(prompt)

--- a/main.py
+++ b/main.py
@@ -183,7 +183,8 @@ if __name__ == "__main__":
         help=(
             "Override research strategy/model. Examples: "
             "'no_research', 'free/nasdaq-eps', 'asknews/news-summaries', "
-            "'asknews/deep-research/low-depth', 'smart-searcher/<model>'."
+            "'asknews/deep-research/low-depth', 'smart-searcher/<model>', "
+            "'tavily-searcher/<model>'."
         ),
     )
     parser.add_argument(

--- a/poetry.lock
+++ b/poetry.lock
@@ -5222,4 +5222,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "9e554f3b03deec099f285578360fd7dfe875359c53e0c9dd615698ec19225855"
+content-hash = "5b3eadef5d68d664f1b21e89d9a7420c9cc368a548dab4b5f8dd0b9421b1b1ac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ package-mode = false
 python = "^3.11"
 python-decouple = "^3.8"
 requests = "^2.32.3"
+aiohttp = "^3.13.2"
 asknews = "^0.13.0"
 numpy = "^2.3.0"
 openai = "^2.0.0"

--- a/tests/test_tavily_searcher.py
+++ b/tests/test_tavily_searcher.py
@@ -1,0 +1,102 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from bot.tavily_searcher import TavilySearcher
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    async def json(self) -> dict:
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+        self.post_calls: list[tuple[str, dict, dict]] = []
+
+    def post(self, url: str, *, json: dict, headers: dict):  # noqa: A002 - matches aiohttp signature
+        self.post_calls.append((url, json, headers))
+        return self._response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class TestTavilySearcher(unittest.IsolatedAsyncioTestCase):
+    async def test_requires_api_key(self) -> None:
+        previous = os.environ.pop("TAVILY_API_KEY", None)
+        self.addCleanup(lambda: os.environ.__setitem__("TAVILY_API_KEY", previous) if previous else None)
+
+        with self.assertRaises(ValueError):
+            TavilySearcher()
+
+    async def test_search_parses_results_and_sends_auth(self) -> None:
+        previous = os.environ.get("TAVILY_API_KEY")
+        os.environ["TAVILY_API_KEY"] = "tvly-test"
+        self.addCleanup(
+            lambda: os.environ.__setitem__("TAVILY_API_KEY", previous)
+            if previous is not None
+            else os.environ.pop("TAVILY_API_KEY", None)
+        )
+
+        fake_payload = {
+            "results": [
+                {
+                    "title": "Result A",
+                    "url": "https://example.com/a",
+                    "content": "Snippet A",
+                    "raw_content": None,
+                    "score": 0.9,
+                },
+                {
+                    "title": "Result B",
+                    "url": "https://example.com/b",
+                    "content": "Snippet B",
+                    "raw_content": "Raw B",
+                    "score": 0.7,
+                },
+            ]
+        }
+        response = _FakeResponse(fake_payload)
+        session = _FakeSession(response)
+
+        with patch("bot.tavily_searcher.aiohttp.ClientSession", return_value=session):
+            searcher = TavilySearcher(
+                timeout_seconds=5,
+                search_depth="basic",
+                topic="general",
+                time_range="week",
+                include_raw_content=True,
+            )
+            results = await searcher.search(query="hello", max_results=2)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].title, "Result A")
+        self.assertEqual(results[0].url, "https://example.com/a")
+        self.assertEqual(results[0].content, "Snippet A")
+
+        self.assertEqual(len(session.post_calls), 1)
+        url, json_body, headers = session.post_calls[0]
+        self.assertEqual(url, "https://api.tavily.com/search")
+        self.assertEqual(headers.get("Authorization"), "Bearer tvly-test")
+        self.assertEqual(json_body.get("query"), "hello")
+        self.assertEqual(json_body.get("max_results"), 2)
+        self.assertEqual(json_body.get("include_raw_content"), True)
+        self.assertEqual(json_body.get("time_range"), "week")
+

--- a/tests/test_tavily_searcher.py
+++ b/tests/test_tavily_searcher.py
@@ -41,7 +41,11 @@ class _FakeSession:
 class TestTavilySearcher(unittest.IsolatedAsyncioTestCase):
     async def test_requires_api_key(self) -> None:
         previous = os.environ.pop("TAVILY_API_KEY", None)
-        self.addCleanup(lambda: os.environ.__setitem__("TAVILY_API_KEY", previous) if previous else None)
+        self.addCleanup(
+            lambda: os.environ.__setitem__("TAVILY_API_KEY", previous)
+            if previous is not None
+            else os.environ.pop("TAVILY_API_KEY", None)
+        )
 
         with self.assertRaises(ValueError):
             TavilySearcher()
@@ -99,4 +103,3 @@ class TestTavilySearcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(json_body.get("max_results"), 2)
         self.assertEqual(json_body.get("include_raw_content"), True)
         self.assertEqual(json_body.get("time_range"), "week")
-


### PR DESCRIPTION
Fixes #22.

Summary:
- Add Tavily provider (`tavily-searcher/*`) with budgets + timeouts.
- Prefer Tavily when `TAVILY_API_KEY` is set; fallback to Exa when Tavily is unavailable/disabled.
- Add circuit-breaker detection for Tavily failures.
- Add unit tests for Tavily provider.

Notes:
- No secrets are logged; keys are read from env only.