### PR TITLE
Add CODEOWNERS for main protections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @RuizhangZhou


### PR DESCRIPTION
Fixes #25.\n\nAdds .github/CODEOWNERS so equire_code_owner_reviews is enforceable.