### PR TITLE
[codex] Log search provider telemetry

### DIFF
--- a/bot/metaculus_bot.py
+++ b/bot/metaculus_bot.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 
 from bot.env import env_bool as _env_bool, env_float as _env_float, env_int as _env_int
 from bot.local_crawl_support import LocalCrawlSupportMixin
+from bot.search_telemetry import record_exa_fallback
 from bot.smart_searcher_circuit import SmartSearcherCircuitMixin
 from bot.tavily_searcher import TavilySmartSearcher
 from bot.tool_router import ToolRouterMixin, ToolRouterPlan
@@ -3330,8 +3331,10 @@ class MetaculusBot(
                                 num_sites_per_search=max(1, num_sites_per_search),
                                 use_advanced_filters=use_advanced_filters,
                             ).invoke(prompt)
+                            record_exa_fallback(success=True)
                             self._smart_searcher_consecutive_failures = 0
                         except Exception as e:
+                            record_exa_fallback(success=False)
                             logger.warning(
                                 "Exa fallback failed; continuing without web search for %s. Error: %s",
                                 question.page_url,
@@ -3487,8 +3490,10 @@ class MetaculusBot(
                                     num_sites_per_search=max(1, num_sites_per_search),
                                     use_advanced_filters=use_advanced_filters,
                                 ).invoke(prompt)
+                                record_exa_fallback(success=True)
                                 self._smart_searcher_consecutive_failures = 0
                             except BaseException as e:
+                                record_exa_fallback(success=False)
                                 if self._is_probably_exa_error(e):
                                     if self._is_exa_nonrecoverable_error(e):
                                         reason = f"nonrecoverable Exa error: {e.__class__.__name__}"
@@ -3563,6 +3568,7 @@ class MetaculusBot(
                                     num_sites_per_search=max(1, num_sites_per_search),
                                     use_advanced_filters=use_advanced_filters,
                                 ).invoke(prompt)
+                                record_exa_fallback(success=True)
                                 self._smart_searcher_consecutive_failures = 0
                                 research = (
                                     fallback_research
@@ -3573,6 +3579,7 @@ class MetaculusBot(
                                     else exa_research
                                 )
                             except Exception as e:
+                                record_exa_fallback(success=False)
                                 logger.warning(
                                     "Exa fallback after empty Tavily result failed for %s. Error: %s",
                                     question.page_url,

--- a/bot/search_telemetry.py
+++ b/bot/search_telemetry.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import atexit
+import logging
+import threading
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+def _tavily_credit_cost(search_depth: str) -> int:
+    depth = (search_depth or "basic").strip().lower()
+    if depth == "advanced":
+        return 2
+    return 1
+
+
+@dataclass
+class TavilyUsage:
+    requests: int = 0
+    successes: int = 0
+    failures: int = 0
+    estimated_credits: int = 0
+    raw_content_requests: int = 0
+    max_results_total: int = 0
+    basic_requests: int = 0
+    advanced_requests: int = 0
+
+
+@dataclass
+class ExaFallbackUsage:
+    attempts: int = 0
+    successes: int = 0
+    failures: int = 0
+
+
+_lock = threading.Lock()
+_tavily = TavilyUsage()
+_exa_fallback = ExaFallbackUsage()
+
+
+def reset_search_provider_telemetry() -> None:
+    global _tavily, _exa_fallback
+    with _lock:
+        _tavily = TavilyUsage()
+        _exa_fallback = ExaFallbackUsage()
+
+
+def record_tavily_search_request(
+    *,
+    search_depth: str,
+    max_results: int,
+    include_raw_content: bool,
+    success: bool,
+) -> None:
+    depth = (search_depth or "basic").strip().lower()
+    with _lock:
+        _tavily.requests += 1
+        _tavily.estimated_credits += _tavily_credit_cost(depth)
+        _tavily.max_results_total += max(0, int(max_results))
+        if include_raw_content:
+            _tavily.raw_content_requests += 1
+        if depth == "advanced":
+            _tavily.advanced_requests += 1
+        else:
+            _tavily.basic_requests += 1
+        if success:
+            _tavily.successes += 1
+        else:
+            _tavily.failures += 1
+
+
+def record_exa_fallback(*, success: bool) -> None:
+    with _lock:
+        _exa_fallback.attempts += 1
+        if success:
+            _exa_fallback.successes += 1
+        else:
+            _exa_fallback.failures += 1
+
+
+def snapshot_search_provider_telemetry() -> dict[str, dict[str, int]]:
+    with _lock:
+        return {
+            "tavily": {
+                "requests": _tavily.requests,
+                "successes": _tavily.successes,
+                "failures": _tavily.failures,
+                "estimated_credits": _tavily.estimated_credits,
+                "raw_content_requests": _tavily.raw_content_requests,
+                "max_results_total": _tavily.max_results_total,
+                "basic_requests": _tavily.basic_requests,
+                "advanced_requests": _tavily.advanced_requests,
+            },
+            "exa_fallback": {
+                "attempts": _exa_fallback.attempts,
+                "successes": _exa_fallback.successes,
+                "failures": _exa_fallback.failures,
+            },
+        }
+
+
+def log_search_provider_telemetry_summary() -> None:
+    snapshot = snapshot_search_provider_telemetry()
+    tavily = snapshot["tavily"]
+    exa = snapshot["exa_fallback"]
+    if tavily["requests"] == 0 and exa["attempts"] == 0:
+        return
+
+    logger.info(
+        "Search provider usage summary: "
+        "tavily_requests=%s tavily_successes=%s tavily_failures=%s "
+        "tavily_estimated_credits=%s tavily_basic_requests=%s "
+        "tavily_advanced_requests=%s tavily_raw_content_requests=%s "
+        "tavily_max_results_total=%s exa_fallback_attempts=%s "
+        "exa_fallback_successes=%s exa_fallback_failures=%s",
+        tavily["requests"],
+        tavily["successes"],
+        tavily["failures"],
+        tavily["estimated_credits"],
+        tavily["basic_requests"],
+        tavily["advanced_requests"],
+        tavily["raw_content_requests"],
+        tavily["max_results_total"],
+        exa["attempts"],
+        exa["successes"],
+        exa["failures"],
+    )
+
+
+atexit.register(log_search_provider_telemetry_summary)

--- a/bot/tavily_searcher.py
+++ b/bot/tavily_searcher.py
@@ -11,6 +11,8 @@ import aiohttp
 from forecasting_tools import GeneralLlm, clean_indents
 from forecasting_tools.util.misc import fill_in_citations
 
+from bot.search_telemetry import record_tavily_search_request
+
 logger = logging.getLogger(__name__)
 
 
@@ -78,11 +80,24 @@ class TavilySearcher:
         if self._time_range:
             payload["time_range"] = self._time_range
 
-        async with self._sem:
-            async with aiohttp.ClientSession(timeout=self._timeout) as session:
-                async with session.post(url, json=payload, headers=headers) as response:
-                    response.raise_for_status()
-                    data: dict = await response.json()
+        data: dict = {}
+        success = False
+        try:
+            async with self._sem:
+                async with aiohttp.ClientSession(timeout=self._timeout) as session:
+                    async with session.post(
+                        url, json=payload, headers=headers
+                    ) as response:
+                        response.raise_for_status()
+                        data = await response.json()
+                        success = True
+        finally:
+            record_tavily_search_request(
+                search_depth=self._search_depth,
+                max_results=max(1, int(max_results)),
+                include_raw_content=self._include_raw_content,
+                success=success,
+            )
 
         results: list[TavilySearchResult] = []
         for item in data.get("results") or []:
@@ -148,6 +163,11 @@ class TavilySmartSearcher:
 
         search_terms = await self._come_up_with_search_queries(prompt)
         results = await self._search(search_terms)
+        logger.info(
+            "TavilySmartSearcher completed searches: searches=%s deduped_results=%s",
+            len(search_terms),
+            len(results),
+        )
         report = await self._compile_report(results, prompt)
         return self._link_citations(report, results)
 

--- a/tests/test_search_telemetry.py
+++ b/tests/test_search_telemetry.py
@@ -1,0 +1,49 @@
+import unittest
+
+from bot.search_telemetry import (
+    record_exa_fallback,
+    record_tavily_search_request,
+    reset_search_provider_telemetry,
+    snapshot_search_provider_telemetry,
+)
+
+
+class TestSearchTelemetry(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_search_provider_telemetry()
+
+    def tearDown(self) -> None:
+        reset_search_provider_telemetry()
+
+    def test_tavily_credit_estimate_uses_search_depth(self) -> None:
+        record_tavily_search_request(
+            search_depth="basic",
+            max_results=8,
+            include_raw_content=False,
+            success=True,
+        )
+        record_tavily_search_request(
+            search_depth="advanced",
+            max_results=5,
+            include_raw_content=True,
+            success=False,
+        )
+
+        telemetry = snapshot_search_provider_telemetry()
+        self.assertEqual(telemetry["tavily"]["requests"], 2)
+        self.assertEqual(telemetry["tavily"]["successes"], 1)
+        self.assertEqual(telemetry["tavily"]["failures"], 1)
+        self.assertEqual(telemetry["tavily"]["estimated_credits"], 3)
+        self.assertEqual(telemetry["tavily"]["max_results_total"], 13)
+        self.assertEqual(telemetry["tavily"]["raw_content_requests"], 1)
+        self.assertEqual(telemetry["tavily"]["basic_requests"], 1)
+        self.assertEqual(telemetry["tavily"]["advanced_requests"], 1)
+
+    def test_exa_fallback_counts_successes_and_failures(self) -> None:
+        record_exa_fallback(success=True)
+        record_exa_fallback(success=False)
+
+        telemetry = snapshot_search_provider_telemetry()
+        self.assertEqual(telemetry["exa_fallback"]["attempts"], 2)
+        self.assertEqual(telemetry["exa_fallback"]["successes"], 1)
+        self.assertEqual(telemetry["exa_fallback"]["failures"], 1)

--- a/tests/test_tavily_searcher.py
+++ b/tests/test_tavily_searcher.py
@@ -2,6 +2,10 @@ import os
 import unittest
 from unittest.mock import patch
 
+from bot.search_telemetry import (
+    reset_search_provider_telemetry,
+    snapshot_search_provider_telemetry,
+)
 from bot.tavily_searcher import TavilySearcher
 
 
@@ -22,6 +26,11 @@ class _FakeResponse:
         return False
 
 
+class _FailingResponse(_FakeResponse):
+    def raise_for_status(self) -> None:
+        raise RuntimeError("tavily failed")
+
+
 class _FakeSession:
     def __init__(self, response: _FakeResponse) -> None:
         self._response = response
@@ -39,6 +48,12 @@ class _FakeSession:
 
 
 class TestTavilySearcher(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        reset_search_provider_telemetry()
+
+    async def asyncTearDown(self) -> None:
+        reset_search_provider_telemetry()
+
     async def test_requires_api_key(self) -> None:
         previous = os.environ.pop("TAVILY_API_KEY", None)
         self.addCleanup(
@@ -103,3 +118,34 @@ class TestTavilySearcher(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(json_body.get("max_results"), 2)
         self.assertEqual(json_body.get("include_raw_content"), True)
         self.assertEqual(json_body.get("time_range"), "week")
+
+        telemetry = snapshot_search_provider_telemetry()
+        self.assertEqual(telemetry["tavily"]["requests"], 1)
+        self.assertEqual(telemetry["tavily"]["successes"], 1)
+        self.assertEqual(telemetry["tavily"]["failures"], 0)
+        self.assertEqual(telemetry["tavily"]["estimated_credits"], 1)
+        self.assertEqual(telemetry["tavily"]["raw_content_requests"], 1)
+        self.assertEqual(telemetry["tavily"]["basic_requests"], 1)
+
+    async def test_search_records_failed_request(self) -> None:
+        previous = os.environ.get("TAVILY_API_KEY")
+        os.environ["TAVILY_API_KEY"] = "tvly-test"
+        self.addCleanup(
+            lambda: os.environ.__setitem__("TAVILY_API_KEY", previous)
+            if previous is not None
+            else os.environ.pop("TAVILY_API_KEY", None)
+        )
+
+        session = _FakeSession(_FailingResponse({}))
+
+        with patch("bot.tavily_searcher.aiohttp.ClientSession", return_value=session):
+            searcher = TavilySearcher(search_depth="advanced")
+            with self.assertRaises(RuntimeError):
+                await searcher.search(query="hello", max_results=3)
+
+        telemetry = snapshot_search_provider_telemetry()
+        self.assertEqual(telemetry["tavily"]["requests"], 1)
+        self.assertEqual(telemetry["tavily"]["successes"], 0)
+        self.assertEqual(telemetry["tavily"]["failures"], 1)
+        self.assertEqual(telemetry["tavily"]["estimated_credits"], 2)
+        self.assertEqual(telemetry["tavily"]["advanced_requests"], 1)


### PR DESCRIPTION
## Summary
- Add process-level search provider telemetry for Tavily requests and Exa fallback attempts.
- Record Tavily success/failure, basic vs advanced depth, raw-content usage, max_results total, and estimated credits.
- Add tests for credit estimates, fallback counters, and Tavily success/failure request accounting.

## Why
Tavily/Exa usage was previously inferred from indirect Actions logs. This makes future tournament runs log the important usage counters directly without exposing queries or secrets.

## Validation
- `python -m unittest tests.test_search_telemetry`
- `python -m py_compile bot\search_telemetry.py bot\tavily_searcher.py bot\metaculus_bot.py tests\test_search_telemetry.py tests\test_tavily_searcher.py`
- `git diff --check`

Note: `tests.test_tavily_searcher` needs project dependencies (`aiohttp`, `forecasting_tools`) that are installed in the GitHub Actions Poetry environment; the local system Python on this machine does not have them.