### PR TITLE
[codex] Add source quality table to Tavily research

### DIFF
--- a/bot/source_quality.py
+++ b/bot/source_quality.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+
+_OFFICIAL_DOMAINS = {
+    "bea.gov",
+    "bls.gov",
+    "cdc.gov",
+    "eia.gov",
+    "fda.gov",
+    "federalregister.gov",
+    "federalreserve.gov",
+    "fred.stlouisfed.org",
+    "noaa.gov",
+    "sec.gov",
+    "usgs.gov",
+    "who.int",
+    "worldbank.org",
+    "imf.org",
+    "oecd.org",
+    "ecb.europa.eu",
+    "ecdc.europa.eu",
+}
+
+_ACADEMIC_DOMAINS = {
+    "arxiv.org",
+    "pubmed.ncbi.nlm.nih.gov",
+    "ncbi.nlm.nih.gov",
+    "nature.com",
+    "science.org",
+    "thelancet.com",
+    "nejm.org",
+}
+
+_MARKET_DOMAINS = {
+    "kalshi.com",
+    "manifold.markets",
+    "metaculus.com",
+    "polymarket.com",
+    "predictit.org",
+}
+
+_SOCIAL_OR_FORUM_DOMAINS = {
+    "facebook.com",
+    "instagram.com",
+    "medium.com",
+    "reddit.com",
+    "substack.com",
+    "tiktok.com",
+    "twitter.com",
+    "x.com",
+    "youtube.com",
+}
+
+
+@dataclass(frozen=True)
+class SourceQuality:
+    domain: str
+    source_type: str
+    reliability: str
+    notes: tuple[str, ...]
+
+
+def canonical_domain(url: str | None) -> str:
+    parsed = urlparse((url or "").strip())
+    host = (parsed.hostname or "").strip().lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def _domain_matches(domain: str, candidates: set[str]) -> bool:
+    return any(domain == item or domain.endswith(f".{item}") for item in candidates)
+
+
+def assess_source_quality(
+    *,
+    url: str | None,
+    score: float | None = None,
+) -> SourceQuality:
+    domain = canonical_domain(url)
+    notes: list[str] = []
+
+    if not domain:
+        return SourceQuality(
+            domain="unknown",
+            source_type="unknown",
+            reliability="low",
+            notes=("missing URL",),
+        )
+
+    if domain.endswith(".gov") or domain.endswith(".mil") or _domain_matches(
+        domain, _OFFICIAL_DOMAINS
+    ):
+        source_type = "official_primary"
+        reliability = "high"
+        notes.append("official or primary-source domain")
+    elif domain.endswith(".edu") or _domain_matches(domain, _ACADEMIC_DOMAINS):
+        source_type = "academic_research"
+        reliability = "high"
+        notes.append("academic or research domain")
+    elif _domain_matches(domain, _MARKET_DOMAINS):
+        source_type = "prediction_market"
+        reliability = "medium"
+        notes.append("market/community forecast signal")
+    elif _domain_matches(domain, _SOCIAL_OR_FORUM_DOMAINS):
+        source_type = "social_or_forum"
+        reliability = "low"
+        notes.append("social, forum, or user-generated source")
+    else:
+        source_type = "secondary_or_unknown"
+        reliability = "medium"
+        notes.append("secondary or unclassified source")
+
+    if score is not None:
+        try:
+            score_value = float(score)
+        except (TypeError, ValueError):
+            score_value = None
+        if score_value is not None and score_value < 0.35:
+            notes.append("low search relevance score")
+
+    return SourceQuality(
+        domain=domain,
+        source_type=source_type,
+        reliability=reliability,
+        notes=tuple(notes),
+    )
+
+
+def format_source_quality_table(results: list[object], *, max_rows: int = 12) -> str:
+    rows: list[str] = [
+        "| # | Domain | Type | Reliability | Notes |",
+        "|---|---|---|---|---|",
+    ]
+    row_count = 0
+    for idx, item in enumerate(results, start=1):
+        if row_count >= max(0, int(max_rows)):
+            break
+        url = getattr(item, "url", None)
+        score = getattr(item, "score", None)
+        quality = assess_source_quality(url=url, score=score)
+        rows.append(
+            "| {idx} | {domain} | {source_type} | {reliability} | {notes} |".format(
+                idx=idx,
+                domain=_escape_table_cell(quality.domain),
+                source_type=_escape_table_cell(quality.source_type),
+                reliability=_escape_table_cell(quality.reliability),
+                notes=_escape_table_cell("; ".join(quality.notes)),
+            )
+        )
+        row_count += 1
+
+    if row_count == 0:
+        return ""
+    return "\n".join(rows)
+
+
+def _escape_table_cell(value: str) -> str:
+    return (value or "").replace("|", "\\|").replace("\n", " ").strip()

--- a/bot/tavily_searcher.py
+++ b/bot/tavily_searcher.py
@@ -12,6 +12,7 @@ from forecasting_tools import GeneralLlm, clean_indents
 from forecasting_tools.util.misc import fill_in_citations
 
 from bot.search_telemetry import record_tavily_search_request
+from bot.source_quality import format_source_quality_table
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +240,8 @@ class TavilySmartSearcher:
         if not search_result_context:
             return "No usable search results found for the query."
 
+        source_quality_table = format_source_quality_table(results)
+
         prompt = clean_indents(
             f"""
             Today is {datetime.now().strftime("%Y-%m-%d")}.
@@ -253,7 +256,13 @@ class TavilySmartSearcher:
             {search_result_context}
             <><><><><><><><><><><><>
 
+            Source quality assessment:
+            <><><><><><><><><><><><>
+            {source_quality_table}
+            <><><><><><><><><><><><>
+
             Please follow the instructions and use the search results to answer the question. Unless the instructions specify otherwise, cite your sources inline using [1], [2], etc and use markdown formatting.
+            Treat low-reliability or social/forum sources as leads rather than decisive evidence. Prefer official, primary, academic, and directly resolution-relevant sources when they conflict with secondary sources.
             """
         )
         return await self._llm.invoke(prompt)

--- a/tests/test_source_quality.py
+++ b/tests/test_source_quality.py
@@ -1,0 +1,40 @@
+import unittest
+from types import SimpleNamespace
+
+from bot.source_quality import (
+    assess_source_quality,
+    canonical_domain,
+    format_source_quality_table,
+)
+
+
+class TestSourceQuality(unittest.TestCase):
+    def test_canonical_domain_strips_www(self) -> None:
+        self.assertEqual(canonical_domain("https://www.cdc.gov/path"), "cdc.gov")
+
+    def test_assesses_official_source_as_high_reliability(self) -> None:
+        quality = assess_source_quality(url="https://www.bls.gov/news.release/foo.htm")
+        self.assertEqual(quality.source_type, "official_primary")
+        self.assertEqual(quality.reliability, "high")
+
+    def test_assesses_prediction_market_as_medium_signal(self) -> None:
+        quality = assess_source_quality(url="https://polymarket.com/event/example")
+        self.assertEqual(quality.source_type, "prediction_market")
+        self.assertEqual(quality.reliability, "medium")
+
+    def test_assesses_social_source_as_low_reliability(self) -> None:
+        quality = assess_source_quality(url="https://reddit.com/r/example/post")
+        self.assertEqual(quality.source_type, "social_or_forum")
+        self.assertEqual(quality.reliability, "low")
+
+    def test_format_source_quality_table_uses_result_indexes(self) -> None:
+        table = format_source_quality_table(
+            [
+                SimpleNamespace(url="https://www.sec.gov/newsroom", score=0.9),
+                SimpleNamespace(url="https://medium.com/post", score=0.2),
+            ]
+        )
+
+        self.assertIn("| 1 | sec.gov | official_primary | high |", table)
+        self.assertIn("| 2 | medium.com | social_or_forum | low |", table)
+        self.assertIn("low search relevance score", table)


### PR DESCRIPTION
## Summary
- Add a reusable `bot.source_quality` module for lightweight source classification.
- Classify search results as official/primary, academic/research, prediction-market, social/forum, or secondary/unknown.
- Include a compact source quality table in Tavily research prompts.
- Tell the research model to treat low-reliability/social sources as leads and prefer primary/official/academic sources when evidence conflicts.

## Why
The bot currently gives all Tavily snippets to the research model with little structure about source strength. This change helps evidence synthesis separate primary evidence from weaker or user-generated sources without adding extra web requests.

## Validation
- `python -m poetry run python -m unittest tests.test_source_quality tests.test_tavily_searcher tests.test_search_telemetry`
- `python -m poetry run python -m py_compile bot\source_quality.py bot\tavily_searcher.py tests\test_source_quality.py`
- `git diff --check`

Related to #36.