### PR TITLE
[codex] Cache research reports across scheduled runs

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -240,6 +240,14 @@ TAVILY_TIME_RANGE=
 TAVILY_INCLUDE_RAW_CONTENT=false
 TAVILY_TIMEOUT_SECONDS=30
 
+# Optional: Research cache
+# Caches generated research reports by question text + resolution criteria + research config.
+# This reduces repeated search/model calls across scheduled runs; keep TTL modest for live news questions.
+BOT_ENABLE_RESEARCH_CACHE=true
+BOT_RESEARCH_CACHE_PATH=.cache/metaculus-bot/research_cache.json
+BOT_RESEARCH_CACHE_TTL_HOURS=24
+BOT_RESEARCH_CACHE_MAX_ENTRIES=500
+
 # Optional: Local question-link crawl (Playwright/Chromium)
 # Fetches the Metaculus question page (optional) + all explicit links in the question text fields,
 # renders them locally (supports JS-heavy pages), extracts main content, and feeds that text into the research prompt.

--- a/.github/workflows/run_bot_on_market_pulse_daily.yaml
+++ b/.github/workflows/run_bot_on_market_pulse_daily.yaml
@@ -64,6 +64,15 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
+      - name: Restore research cache
+        uses: actions/cache@v4
+        with:
+          path: .cache/metaculus-bot
+          key: research-cache-market-pulse-${{ github.run_id }}
+          restore-keys: |
+            research-cache-market-pulse-
+            research-cache-
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
@@ -110,6 +119,11 @@ jobs:
           METACULUS_TOKEN: ${{ secrets.METACULUS_TOKEN }}
           EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          TAVILY_SEARCH_DEPTH: ${{ vars.TAVILY_SEARCH_DEPTH || 'basic' }}
+          TAVILY_TOPIC: ${{ vars.TAVILY_TOPIC || 'general' }}
+          TAVILY_TIME_RANGE: ${{ vars.TAVILY_TIME_RANGE }}
+          TAVILY_INCLUDE_RAW_CONTENT: ${{ vars.TAVILY_INCLUDE_RAW_CONTENT || 'false' }}
+          TAVILY_TIMEOUT_SECONDS: ${{ vars.TAVILY_TIMEOUT_SECONDS || '30' }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT || secrets.AZURE_OPENAI_ENDPOINT }}
@@ -147,7 +161,15 @@ jobs:
           MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
           MATRIX_NOTIFY_ALWAYS: "false"
           SEC_USER_AGENT: ${{ vars.SEC_USER_AGENT || secrets.SEC_USER_AGENT }}
-          BOT_ENABLE_LOCAL_QUESTION_CRAWL: "true"
+          BOT_ENABLE_RESEARCH_CACHE: ${{ vars.BOT_ENABLE_RESEARCH_CACHE || 'true' }}
+          BOT_RESEARCH_CACHE_PATH: ${{ vars.BOT_RESEARCH_CACHE_PATH || '.cache/metaculus-bot/research_cache.json' }}
+          BOT_RESEARCH_CACHE_TTL_HOURS: ${{ vars.BOT_RESEARCH_CACHE_TTL_HOURS || '24' }}
+          BOT_RESEARCH_CACHE_MAX_ENTRIES: ${{ vars.BOT_RESEARCH_CACHE_MAX_ENTRIES || '500' }}
+          BOT_ENABLE_LOCAL_QUESTION_CRAWL: ${{ vars.BOT_ENABLE_LOCAL_QUESTION_CRAWL || 'true' }}
+          BOT_LOCAL_CRAWL_INCLUDE_QUESTION_PAGE: ${{ vars.BOT_LOCAL_CRAWL_INCLUDE_QUESTION_PAGE || 'false' }}
+          BOT_LOCAL_CRAWL_MAX_URLS: ${{ vars.BOT_LOCAL_CRAWL_MAX_URLS }}
+          BOT_LOCAL_CRAWL_TOTAL_CHAR_BUDGET: ${{ vars.BOT_LOCAL_CRAWL_TOTAL_CHAR_BUDGET }}
+          BOT_LOCAL_CRAWL_PER_URL_CHAR_BUDGET: ${{ vars.BOT_LOCAL_CRAWL_PER_URL_CHAR_BUDGET }}
 
       - name: Retrospective (resolved questions)
         run: |

--- a/.github/workflows/run_bot_on_tournament.yaml
+++ b/.github/workflows/run_bot_on_tournament.yaml
@@ -72,6 +72,14 @@ jobs:
       #   with:
       #     path: .venv
       #     key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Restore research cache
+        uses: actions/cache@v4
+        with:
+          path: .cache/metaculus-bot
+          key: research-cache-tournaments-${{ github.run_id }}
+          restore-keys: |
+            research-cache-tournaments-
+            research-cache-
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
@@ -145,6 +153,11 @@ jobs:
         env:
           METACULUS_TOKEN: ${{ secrets.METACULUS_TOKEN }} # replace this with the name of the variable under which you stored your own Metaculus token
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          TAVILY_SEARCH_DEPTH: ${{ vars.TAVILY_SEARCH_DEPTH || 'basic' }}
+          TAVILY_TOPIC: ${{ vars.TAVILY_TOPIC || 'general' }}
+          TAVILY_TIME_RANGE: ${{ vars.TAVILY_TIME_RANGE }}
+          TAVILY_INCLUDE_RAW_CONTENT: ${{ vars.TAVILY_INCLUDE_RAW_CONTENT || 'false' }}
+          TAVILY_TIMEOUT_SECONDS: ${{ vars.TAVILY_TIMEOUT_SECONDS || '30' }}
           EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
@@ -189,6 +202,13 @@ jobs:
           MATRIX_ROOM_ID: ${{ secrets.MATRIX_ROOM_ID }}
           MATRIX_NOTIFY_ALWAYS: "false"
           SEC_USER_AGENT: ${{ vars.SEC_USER_AGENT || secrets.SEC_USER_AGENT }}
-          BOT_ENABLE_LOCAL_QUESTION_CRAWL: "true"
-          BOT_LOCAL_CRAWL_INCLUDE_QUESTION_PAGE: "false"
+          BOT_ENABLE_RESEARCH_CACHE: ${{ vars.BOT_ENABLE_RESEARCH_CACHE || 'true' }}
+          BOT_RESEARCH_CACHE_PATH: ${{ vars.BOT_RESEARCH_CACHE_PATH || '.cache/metaculus-bot/research_cache.json' }}
+          BOT_RESEARCH_CACHE_TTL_HOURS: ${{ vars.BOT_RESEARCH_CACHE_TTL_HOURS || '24' }}
+          BOT_RESEARCH_CACHE_MAX_ENTRIES: ${{ vars.BOT_RESEARCH_CACHE_MAX_ENTRIES || '500' }}
+          BOT_ENABLE_LOCAL_QUESTION_CRAWL: ${{ vars.BOT_ENABLE_LOCAL_QUESTION_CRAWL || 'true' }}
+          BOT_LOCAL_CRAWL_INCLUDE_QUESTION_PAGE: ${{ vars.BOT_LOCAL_CRAWL_INCLUDE_QUESTION_PAGE || 'false' }}
+          BOT_LOCAL_CRAWL_MAX_URLS: ${{ vars.BOT_LOCAL_CRAWL_MAX_URLS }}
+          BOT_LOCAL_CRAWL_TOTAL_CHAR_BUDGET: ${{ vars.BOT_LOCAL_CRAWL_TOTAL_CHAR_BUDGET }}
+          BOT_LOCAL_CRAWL_PER_URL_CHAR_BUDGET: ${{ vars.BOT_LOCAL_CRAWL_PER_URL_CHAR_BUDGET }}
           BOT_TOURNAMENT_TIMEOUT_MINUTES: ${{ vars.BOT_TOURNAMENT_TIMEOUT_MINUTES }}

--- a/bot/metaculus_bot.py
+++ b/bot/metaculus_bot.py
@@ -25,6 +25,11 @@ from urllib.parse import urlparse
 
 from bot.env import env_bool as _env_bool, env_float as _env_float, env_int as _env_int
 from bot.local_crawl_support import LocalCrawlSupportMixin
+from bot.research_cache import (
+    ResearchCache,
+    build_research_cache_key,
+    research_cache_options_from_env,
+)
 from bot.search_telemetry import record_exa_fallback
 from bot.smart_searcher_circuit import SmartSearcherCircuitMixin
 from bot.tavily_searcher import TavilySmartSearcher
@@ -2743,6 +2748,14 @@ class MetaculusBot(
             if not researcher or researcher == "None" or researcher == "no_research":
                 return ""
 
+            researcher_cache_name = GeneralLlm.to_model_name(researcher)
+            research_cache = ResearchCache()
+            research_cache_key = build_research_cache_key(
+                question=question,
+                researcher_name=researcher_cache_name,
+                options=research_cache_options_from_env(),
+            )
+
             tool_trace: dict | None = None
             if self._tool_trace_enabled():
                 try:
@@ -2763,6 +2776,21 @@ class MetaculusBot(
                         pass
                 except Exception:
                     tool_trace = None
+
+            cached_research = research_cache.get(research_cache_key)
+            if cached_research is not None:
+                logger.info("Research cache hit for URL %s", question.page_url)
+                if tool_trace is not None:
+                    tool_trace_record_value(
+                        tool_trace, key="research_cache_hit", value=True
+                    )
+                return cached_research
+            if research_cache.enabled:
+                logger.info("Research cache miss for URL %s", question.page_url)
+                if tool_trace is not None:
+                    tool_trace_record_value(
+                        tool_trace, key="research_cache_hit", value=False
+                    )
 
             local_crawl_context = await self._get_local_crawl_context_cached(question)
             if tool_trace is not None:
@@ -2814,9 +2842,10 @@ class MetaculusBot(
                 logger.info(
                     f"Found Research for URL {question.page_url} (free strategy {strategy}):\n{combined}"
                 )
+                research_cache.set(research_cache_key, combined)
                 return combined
 
-            researcher_model_name = GeneralLlm.to_model_name(researcher)
+            researcher_model_name = researcher_cache_name
             researcher_model_name_lower = researcher_model_name.lower()
             logger.info(f"Researcher strategy/model: {researcher_model_name}")
 
@@ -3887,6 +3916,7 @@ class MetaculusBot(
                     max_urls=self._tool_trace_max_urls(),
                 )
             logger.info(f"Found Research for URL {question.page_url}:\n{research}")
+            research_cache.set(research_cache_key, research)
             return research
 
     def _create_unified_explanation(

--- a/bot/research_cache.py
+++ b/bot/research_cache.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from bot.env import env_bool, env_float, env_int
+
+logger = logging.getLogger(__name__)
+
+_CACHE_VERSION = 1
+_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class ResearchCacheConfig:
+    enabled: bool
+    path: Path
+    ttl_hours: float
+    max_entries: int
+
+    @classmethod
+    def from_env(cls) -> "ResearchCacheConfig":
+        default_path = ".cache/metaculus-bot/research_cache.json"
+        return cls(
+            enabled=env_bool("BOT_ENABLE_RESEARCH_CACHE", True),
+            path=Path(os.getenv("BOT_RESEARCH_CACHE_PATH", default_path)),
+            ttl_hours=max(0.0, env_float("BOT_RESEARCH_CACHE_TTL_HOURS", 24.0)),
+            max_entries=max(1, env_int("BOT_RESEARCH_CACHE_MAX_ENTRIES", 500)),
+        )
+
+
+class ResearchCache:
+    def __init__(self, config: ResearchCacheConfig | None = None) -> None:
+        self._config = config or ResearchCacheConfig.from_env()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._config.enabled)
+
+    def get(self, key: str) -> str | None:
+        if not self.enabled:
+            return None
+        now = time.time()
+        with _LOCK:
+            payload = self._read_payload()
+            entry = payload.get("entries", {}).get(key)
+            if not isinstance(entry, dict):
+                return None
+            created_at = _as_float(entry.get("created_at"))
+            research = entry.get("research")
+            if not isinstance(research, str) or not research.strip():
+                return None
+            if self._is_expired(created_at, now):
+                return None
+            entry["last_accessed_at"] = now
+            entry["hits"] = int(entry.get("hits") or 0) + 1
+            self._write_payload(payload)
+            return research
+
+    def set(self, key: str, research: str) -> None:
+        if not self.enabled:
+            return
+        research = (research or "").strip()
+        if not research:
+            return
+        now = time.time()
+        with _LOCK:
+            payload = self._read_payload()
+            entries = payload.setdefault("entries", {})
+            if not isinstance(entries, dict):
+                entries = {}
+                payload["entries"] = entries
+            entries[key] = {
+                "created_at": now,
+                "last_accessed_at": now,
+                "hits": 0,
+                "research": research,
+            }
+            self._prune(payload, now)
+            self._write_payload(payload)
+
+    def _is_expired(self, created_at: float | None, now: float) -> bool:
+        if created_at is None:
+            return True
+        ttl = self._config.ttl_hours
+        if ttl <= 0:
+            return True
+        return (now - created_at) > ttl * 3600.0
+
+    def _read_payload(self) -> dict[str, Any]:
+        path = self._config.path
+        if not path.exists():
+            return {"version": _CACHE_VERSION, "entries": {}}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning("Research cache read failed; ignoring cache. Error: %s", e)
+            return {"version": _CACHE_VERSION, "entries": {}}
+        if not isinstance(data, dict):
+            return {"version": _CACHE_VERSION, "entries": {}}
+        if data.get("version") != _CACHE_VERSION:
+            return {"version": _CACHE_VERSION, "entries": {}}
+        entries = data.get("entries")
+        if not isinstance(entries, dict):
+            data["entries"] = {}
+        return data
+
+    def _write_payload(self, payload: dict[str, Any]) -> None:
+        path = self._config.path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f"{path.name}.", suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(payload, f, ensure_ascii=False, sort_keys=True)
+            Path(tmp_name).replace(path)
+        except Exception:
+            try:
+                Path(tmp_name).unlink(missing_ok=True)
+            except Exception:
+                pass
+            raise
+
+    def _prune(self, payload: dict[str, Any], now: float) -> None:
+        entries = payload.get("entries")
+        if not isinstance(entries, dict):
+            payload["entries"] = {}
+            return
+        for key, entry in list(entries.items()):
+            if not isinstance(entry, dict) or self._is_expired(
+                _as_float(entry.get("created_at")), now
+            ):
+                entries.pop(key, None)
+        if len(entries) <= self._config.max_entries:
+            return
+        ordered = sorted(
+            entries.items(),
+            key=lambda item: _as_float(item[1].get("last_accessed_at"))
+            if isinstance(item[1], dict)
+            else 0.0,
+        )
+        for key, _entry in ordered[: max(0, len(entries) - self._config.max_entries)]:
+            entries.pop(key, None)
+
+
+def build_research_cache_key(
+    *,
+    question: object,
+    researcher_name: str,
+    options: dict[str, Any] | None = None,
+) -> str:
+    payload = {
+        "version": _CACHE_VERSION,
+        "question": {
+            "page_url": getattr(question, "page_url", None),
+            "question_text": getattr(question, "question_text", None),
+            "background_info": getattr(question, "background_info", None),
+            "resolution_criteria": getattr(question, "resolution_criteria", None),
+            "fine_print": getattr(question, "fine_print", None),
+            "close_time": _stable_time(getattr(question, "close_time", None)),
+            "scheduled_resolution_time": _stable_time(
+                getattr(question, "scheduled_resolution_time", None)
+            ),
+        },
+        "researcher_name": researcher_name,
+        "options": options or {},
+    }
+    raw = json.dumps(payload, ensure_ascii=False, sort_keys=True, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def research_cache_options_from_env() -> dict[str, Any]:
+    names = [
+        "BOT_ENABLE_LOCAL_QUESTION_CRAWL",
+        "BOT_LOCAL_CRAWL_INCLUDE_QUESTION_PAGE",
+        "BOT_ENABLE_TOOL_ROUTER",
+        "SMART_SEARCHER_NUM_SEARCHES",
+        "SMART_SEARCHER_NUM_SITES_PER_SEARCH",
+        "SMART_SEARCHER_USE_ADVANCED_FILTERS",
+        "TAVILY_SEARCH_DEPTH",
+        "TAVILY_TOPIC",
+        "TAVILY_TIME_RANGE",
+        "TAVILY_INCLUDE_RAW_CONTENT",
+        "BOT_OFFICIAL_TOTAL_CHAR_BUDGET",
+    ]
+    return {name: os.getenv(name, "") for name in names}
+
+
+def _stable_time(value: object) -> str | None:
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return isoformat()
+    return None
+
+
+def _as_float(value: object) -> float | None:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None

--- a/tests/test_research_cache.py
+++ b/tests/test_research_cache.py
@@ -1,0 +1,146 @@
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from bot import metaculus_bot as metaculus_bot_module
+from bot.research_cache import (
+    ResearchCache,
+    ResearchCacheConfig,
+    build_research_cache_key,
+    research_cache_options_from_env,
+)
+
+
+class TestResearchCache(unittest.TestCase):
+    def test_key_changes_when_resolution_criteria_changes(self) -> None:
+        q1 = SimpleNamespace(
+            page_url="https://example.com/q/1",
+            question_text="Will X happen?",
+            background_info="",
+            resolution_criteria="Resolve yes if X happens.",
+            fine_print="",
+            close_time=None,
+            scheduled_resolution_time=None,
+        )
+        q2 = SimpleNamespace(**{**q1.__dict__, "resolution_criteria": "Changed."})
+
+        key1 = build_research_cache_key(
+            question=q1, researcher_name="tavily-searcher/kiconnect"
+        )
+        key2 = build_research_cache_key(
+            question=q2, researcher_name="tavily-searcher/kiconnect"
+        )
+
+        self.assertNotEqual(key1, key2)
+
+    def test_cache_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = ResearchCache(
+                ResearchCacheConfig(
+                    enabled=True,
+                    path=Path(tmp) / "research_cache.json",
+                    ttl_hours=24,
+                    max_entries=10,
+                )
+            )
+            cache.set("abc", "research text")
+
+            self.assertEqual(cache.get("abc"), "research text")
+
+    def test_cache_respects_ttl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cache = ResearchCache(
+                ResearchCacheConfig(
+                    enabled=True,
+                    path=Path(tmp) / "research_cache.json",
+                    ttl_hours=0.000001,
+                    max_entries=10,
+                )
+            )
+            cache.set("abc", "research text")
+            time.sleep(0.01)
+
+            self.assertIsNone(cache.get("abc"))
+
+    def test_disabled_cache_does_not_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "research_cache.json"
+            cache = ResearchCache(
+                ResearchCacheConfig(
+                    enabled=False,
+                    path=path,
+                    ttl_hours=24,
+                    max_entries=10,
+                )
+            )
+            cache.set("abc", "research text")
+
+            self.assertIsNone(cache.get("abc"))
+            self.assertFalse(path.exists())
+
+
+class TestResearchCacheIntegration(unittest.IsolatedAsyncioTestCase):
+    async def test_run_research_cache_hit_skips_retrieval(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "research_cache.json"
+            previous_env = {
+                "BOT_ENABLE_RESEARCH_CACHE": None,
+                "BOT_RESEARCH_CACHE_PATH": None,
+                "BOT_RESEARCH_CACHE_TTL_HOURS": None,
+                "BOT_ENABLE_TOOL_TRACE": None,
+            }
+            import os
+
+            for key in previous_env:
+                previous_env[key] = os.environ.get(key)
+            try:
+                os.environ["BOT_ENABLE_RESEARCH_CACHE"] = "true"
+                os.environ["BOT_RESEARCH_CACHE_PATH"] = str(path)
+                os.environ["BOT_RESEARCH_CACHE_TTL_HOURS"] = "24"
+                os.environ["BOT_ENABLE_TOOL_TRACE"] = "false"
+
+                question = SimpleNamespace(
+                    page_url="https://example.com/q/1",
+                    question_text="Will X happen?",
+                    background_info="",
+                    resolution_criteria="Resolve yes if X happens.",
+                    fine_print="",
+                    close_time=None,
+                    scheduled_resolution_time=None,
+                )
+                key = build_research_cache_key(
+                    question=question,
+                    researcher_name="free/test",
+                    options=research_cache_options_from_env(),
+                )
+                ResearchCache().set(key, "cached research")
+
+                bot = metaculus_bot_module.MetaculusBot(
+                    research_reports_per_question=1,
+                    predictions_per_research_report=1,
+                    use_research_summary_to_forecast=False,
+                    publish_reports_to_metaculus=False,
+                    folder_to_save_reports_to=None,
+                    skip_previously_forecasted_questions=False,
+                    llms={
+                        "default": "no_research",
+                        "summarizer": "no_research",
+                        "parser": "no_research",
+                        "researcher": "free/test",
+                    },
+                )
+
+                async def fail_if_called(_question):
+                    raise AssertionError("cache hit should skip retrieval")
+
+                bot._get_local_crawl_context_cached = fail_if_called
+
+                self.assertEqual(await bot.run_research(question), "cached research")
+            finally:
+                for key, value in previous_env.items():
+                    if value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = value


### PR DESCRIPTION
## Summary
- Add a file-backed research cache keyed by question text, resolution criteria, researcher, and major research/search options.
- Check the cache at the start of `run_research`; on hit, skip local crawl, official source fetches, Tavily/Exa, and research LLM synthesis.
- Store sanitized research reports after successful research.
- Restore `.cache/metaculus-bot` in tournament and Market Pulse GitHub Actions using `actions/cache`.
- Expose Tavily, local crawl, and research-cache tuning vars in the active research workflows.
- Document cache env vars in `.env.template`.

## Why
Scheduled runs repeatedly inspect the same tournaments. Even with previously forecasted questions skipped, manual reruns and unsubmitted/newly changed runs can repeat expensive research. This is a first-stage implementation of #37 to reduce search credits, model calls, and latency while keeping a modest default TTL for current-events questions.

## Validation
- `python -m poetry run python -m unittest tests.test_research_cache tests.test_forecast_guardrails tests.test_source_quality`
- `python -m poetry run python -m unittest tests.test_research_cache`
- `python -m poetry run python -m py_compile bot\research_cache.py bot\metaculus_bot.py tests\test_research_cache.py`
- `git diff --check`

Related to #37.