### PR TITLE
Upgrade cache actions for Node 24

### DIFF
--- a/.github/workflows/daily_digest.yaml
+++ b/.github/workflows/daily_digest.yaml
@@ -45,7 +45,7 @@ jobs:
           installer-parallel: true
 
       - name: Restore digest state
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .state
           key: digest-state-${{ github.run_id }}

--- a/.github/workflows/run_bot_on_market_pulse_daily.yaml
+++ b/.github/workflows/run_bot_on_market_pulse_daily.yaml
@@ -65,7 +65,7 @@ jobs:
           installer-parallel: true
 
       - name: Restore research cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .cache/metaculus-bot
           key: research-cache-market-pulse-${{ github.run_id }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/run_bot_on_tournament.yaml
+++ b/.github/workflows/run_bot_on_tournament.yaml
@@ -68,12 +68,12 @@ jobs:
       # Adding the below will make the workflow faster, but will mean you don't automatically get updates from forecasting-tools and other packages
       # - name: Load cached venv
       #   id: cached-poetry-dependencies
-      #   uses: actions/cache@v4
+      #   uses: actions/cache@v5
       #   with:
       #     path: .venv
       #     key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Restore research cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .cache/metaculus-bot
           key: research-cache-tournaments-${{ github.run_id }}
@@ -82,7 +82,7 @@ jobs:
             research-cache-
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/test_bot.yaml
+++ b/.github/workflows/test_bot.yaml
@@ -30,7 +30,7 @@ jobs:
       # Adding the below will make the workflow faster, but will mean you don't automatically get updates from forecasting-tools and other packages
       # - name: Load cached venv
       #   id: cached-poetry-dependencies
-      #   uses: actions/cache@v4
+      #   uses: actions/cache@v5
       #   with:
       #     path: .venv
       #     key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
## Summary
- Upgrade workflow cache steps from actions/cache@v4 to actions/cache@v5.
- Update commented cache examples so future copies use the Node 24 runtime action.

## Why
GitHub Actions is moving JavaScript actions from Node.js 20 to Node.js 24. `actions/cache@v5` is the cache action version that runs on Node.js 24.

## Validation
- `rg -n "uses:\\s*actions/cache@v4|actions/cache@v4" .github\\workflows` returns no matches.
- `poetry run python -c "import yaml; from pathlib import Path; [yaml.safe_load(p.read_text(encoding='utf-8')) for p in Path('.github/workflows').glob('*.yaml')]; print('workflow yaml parse ok')"`
- `git diff --check`

Closes #46