### PR TITLE
Extract financial symbols from source URLs

### DIFF
--- a/bot/financial_data_context.py
+++ b/bot/financial_data_context.py
@@ -6,7 +6,7 @@ import math
 import re
 import statistics
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, unquote, urlparse
 
 import requests
 
@@ -104,6 +104,20 @@ _FINANCIAL_TERMS = re.compile(
     re.IGNORECASE,
 )
 
+_YAHOO_SYMBOL_LABELS = {
+    "^GSPC": "S&P 500",
+    "^IXIC": "Nasdaq Composite",
+    "^NDX": "Nasdaq-100",
+    "^DJI": "Dow Jones Industrial Average",
+    "^RUT": "Russell 2000",
+    "^VIX": "CBOE Volatility Index",
+    "BTC-USD": "Bitcoin USD",
+    "ETH-USD": "Ethereum USD",
+    "CL=F": "WTI crude oil futures",
+    "BZ=F": "Brent crude oil futures",
+    "GC=F": "Gold futures",
+}
+
 _THRESHOLD_RE = re.compile(
     r"\b(?P<direction>above|over|exceed(?:s|ed|ing)?|greater than|at least|"
     r"below|under|less than|at most|no more than|reach(?:es|ed|ing)?|hit(?:s|ting)?)"
@@ -137,6 +151,70 @@ def _add_instrument(
     instruments.append(
         FinancialInstrumentSpec(symbol=symbol.strip(), label=label.strip(), source=source)
     )
+
+
+def _normalize_market_symbol(symbol: str) -> str:
+    symbol = unquote(symbol or "").strip().upper()
+    symbol = symbol.strip("/")
+    symbol = re.sub(r"[^A-Z0-9.^=-]", "", symbol)
+    return symbol[:20]
+
+
+def _label_for_symbol(symbol: str) -> str:
+    normalized = symbol.upper()
+    if normalized in _YAHOO_SYMBOL_LABELS:
+        return _YAHOO_SYMBOL_LABELS[normalized]
+    if normalized.startswith("^"):
+        return f"{normalized} index"
+    if normalized.endswith("-USD"):
+        return normalized.replace("-", " ")
+    if normalized.endswith("=F"):
+        return f"{normalized} futures"
+    return f"{normalized} equity"
+
+
+def _add_instruments_from_explicit_urls(
+    instruments: list[FinancialInstrumentSpec], *, text: str
+) -> None:
+    for raw_url in extract_http_urls(text):
+        parsed = urlparse(raw_url)
+        host = parsed.netloc.lower()
+        path_parts = [part for part in parsed.path.split("/") if part]
+        symbol = ""
+        source = ""
+
+        if "finance.yahoo.com" in host:
+            if len(path_parts) >= 2 and path_parts[0].lower() == "quote":
+                symbol = _normalize_market_symbol(path_parts[1])
+                source = "explicit-yahoo-url"
+        elif "query1.finance.yahoo.com" in host or "query2.finance.yahoo.com" in host:
+            lowered = [part.lower() for part in path_parts]
+            if len(path_parts) >= 4 and lowered[:3] == ["v8", "finance", "chart"]:
+                symbol = _normalize_market_symbol(path_parts[3])
+                source = "explicit-yahoo-chart-url"
+        elif "nasdaq.com" in host:
+            lowered = [part.lower() for part in path_parts]
+            if len(path_parts) >= 3 and lowered[:2] == ["api", "quote"]:
+                symbol = _normalize_market_symbol(path_parts[2])
+                source = "explicit-nasdaq-api-url"
+            elif "quote" in lowered:
+                idx = lowered.index("quote")
+                if idx + 1 < len(path_parts):
+                    symbol = _normalize_market_symbol(path_parts[idx + 1])
+                    source = "explicit-nasdaq-url"
+            elif "stocks" in lowered:
+                idx = lowered.index("stocks")
+                if idx + 1 < len(path_parts):
+                    symbol = _normalize_market_symbol(path_parts[idx + 1])
+                    source = "explicit-nasdaq-url"
+
+        if symbol:
+            _add_instrument(
+                instruments,
+                symbol=symbol,
+                label=_label_for_symbol(symbol),
+                source=source or "explicit-source-url",
+            )
 
 
 def _extract_threshold(text: str) -> tuple[float | None, str | None]:
@@ -197,6 +275,7 @@ def build_financial_question_spec(
         return None
 
     instruments: list[FinancialInstrumentSpec] = []
+    _add_instruments_from_explicit_urls(instruments, text=text)
     for pattern, symbol, label in _SYMBOL_PATTERNS:
         if pattern.search(text):
             _add_instrument(

--- a/tests/test_financial_data_context.py
+++ b/tests/test_financial_data_context.py
@@ -57,6 +57,43 @@ class TestFinancialDataContext(unittest.TestCase):
         self.assertTrue(spec.needs_market_close)
         self.assertTrue(spec.should_skip_broad_news)
 
+    def test_build_spec_from_explicit_yahoo_resolution_url(self) -> None:
+        question = SimpleNamespace(
+            question_text="Will this index close above 7000?",
+            background_info="",
+            resolution_criteria=(
+                "Resolved using https://finance.yahoo.com/quote/%5EGSPC/ at market close."
+            ),
+            fine_print="",
+        )
+
+        spec = build_financial_question_spec(question)
+
+        self.assertIsNotNone(spec)
+        assert spec is not None
+        self.assertEqual(spec.instruments[0].symbol, "^GSPC")
+        self.assertEqual(spec.instruments[0].source, "explicit-yahoo-url")
+        self.assertEqual(spec.target_kind, "index_level")
+        self.assertTrue(spec.has_explicit_source_urls)
+
+    def test_build_spec_from_explicit_nasdaq_api_url(self) -> None:
+        question = SimpleNamespace(
+            question_text="Will this stock close above 250?",
+            background_info="",
+            resolution_criteria=(
+                "Use https://api.nasdaq.com/api/quote/AAPL/info?assetclass=stocks."
+            ),
+            fine_print="",
+        )
+
+        spec = build_financial_question_spec(question)
+
+        self.assertIsNotNone(spec)
+        assert spec is not None
+        self.assertEqual(spec.instruments[0].symbol, "AAPL")
+        self.assertEqual(spec.instruments[0].source, "explicit-nasdaq-api-url")
+        self.assertEqual(spec.target_kind, "equity_price")
+
     @patch("bot.financial_data_context.requests.get")
     def test_prefetch_yahoo_snapshot_renders_quote_and_volatility(self, mock_get) -> None:
         base_ts = 1_767_225_600  # 2026-01-01T00:00:00Z


### PR DESCRIPTION
## Summary
- Parse explicit Yahoo Finance and Nasdaq source URLs into financial instruments.
- Prefer instruments from resolution/source URLs before keyword and inferred ticker heuristics.
- Add tests for Yahoo Finance `^GSPC` links and Nasdaq quote API links.

## Why
Some financial questions provide the authoritative market-data source as a URL without repeating the ticker/index name in plain text. Extracting symbols from those URLs makes the fresh market-data snapshot and baseline probability work even when the natural-language title is vague.

## Validation
- `poetry run python -m unittest tests.test_financial_data_context`
- `poetry run python -m unittest discover tests`
- `python -m compileall bot tests`
- `git diff --check`

Closes #50