### PR TITLE
Resolve tournament slugs from the API instead of hard-coding them

### DIFF
--- a/.github/workflows/run_bot_on_market_pulse_daily.yaml
+++ b/.github/workflows/run_bot_on_market_pulse_daily.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tournament:
-        description: "Tournament slug or URL (default: MARKET_PULSE_TOURNAMENT var or market-pulse-26q3)"
+        description: "Tournament slug or URL. Empty = MARKET_PULSE_TOURNAMENT var, or auto-discover the running quarter."
         required: false
         default: ""
         type: string
@@ -109,7 +109,7 @@ jobs:
           SMART_SEARCHER_NUM_SITES_PER_SEARCH="${{ github.event.inputs.smart_searcher_num_sites_per_search }}"
           SMART_SEARCHER_USE_ADVANCED_FILTERS="${{ github.event.inputs.smart_searcher_use_advanced_filters }}"
 
-          if [ -z "$TOURNAMENT" ]; then TOURNAMENT="${MARKET_PULSE_TOURNAMENT:-market-pulse-26q3}"; fi
+          if [ -z "$TOURNAMENT" ]; then TOURNAMENT="${MARKET_PULSE_TOURNAMENT:-auto}"; fi
           if [ -z "$RESEARCHER" ]; then RESEARCHER="tavily-searcher/kiconnect"; fi
           if [ -z "$SMART_SEARCHER_NUM_SEARCHES" ]; then SMART_SEARCHER_NUM_SEARCHES="3"; fi
           if [ -z "$SMART_SEARCHER_NUM_SITES_PER_SEARCH" ]; then SMART_SEARCHER_NUM_SITES_PER_SEARCH="8"; fi
@@ -231,7 +231,7 @@ jobs:
         run: |
           set -o pipefail
           TOURNAMENT="${{ github.event.inputs.tournament }}"
-          if [ -z "$TOURNAMENT" ]; then TOURNAMENT="${MARKET_PULSE_TOURNAMENT:-market-pulse-26q3}"; fi
+          if [ -z "$TOURNAMENT" ]; then TOURNAMENT="${MARKET_PULSE_TOURNAMENT:-auto}"; fi
           poetry run python main.py --mode retrospective --tournament "$TOURNAMENT" | tee retrospective_summary.md | tee -a "$GITHUB_STEP_SUMMARY"
           if [ "${MATRIX_NOTIFY_RETROSPECTIVE:-true}" = "true" ]; then
             poetry run python - <<'PY'

--- a/.github/workflows/run_bot_on_tournament.yaml
+++ b/.github/workflows/run_bot_on_tournament.yaml
@@ -1,10 +1,10 @@
-name: Forecast on Tournaments (Summer FutureEval + minibench)
+name: Forecast on Tournaments (seasonal bot tournament + minibench)
 
 on:
   workflow_dispatch:
     inputs:
       tournament:
-        description: "Single tournament to run (leave empty for Summer FutureEval + minibench)"
+        description: "Single tournament to run. Empty = the running seasonal bot tournament + minibench."
         required: false
         default: ""
         type: string
@@ -124,8 +124,8 @@ jobs:
             TOURNAMENTS=("$MANUAL_TOURNAMENT")
           else
             TOURNAMENTS=(
-              "${BOT_TOURNAMENT:-summer-futureeval-2026}"
-              "https://www.metaculus.com/tournament/minibench/"
+              "${BOT_TOURNAMENT:-auto:futureeval}"
+              "auto:minibench"
             )
           fi
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from digest_mode import (
     matrix_send_message,
     run_digest,
 )
+from tournament_resolver import expand_identifiers
 from tournament_update import select_questions_for_tournament_update
 from forecasting_tools import GeneralLlm, MetaculusClient
 
@@ -117,6 +118,28 @@ def _validate_and_normalize_metaculus_token() -> None:
         )
         matrix_send_message(f"Metaculus bot error: {message}")
         raise SystemExit(message)
+
+
+def _resolve_tournaments(identifiers: list[str], *, family: str) -> list[str]:
+    """Turn any ``auto`` marker into the tournament that is actually running.
+
+    Explicit slugs are passed through, so pinning one still works. Failing to
+    reach the API is fatal on purpose: forecasting against a stale hard-coded
+    slug looks like success (exit 0, ``total_open=0``) and is how this bot once
+    forecast nothing for 149 days.
+    """
+    try:
+        resolved = expand_identifiers(identifiers, default_family=family)
+    except Exception as exc:  # noqa: BLE001 - surfaced as a clean exit below
+        raise SystemExit(
+            f"Could not resolve tournaments {identifiers} (family={family}): {exc!r}"
+        ) from exc
+    if not resolved:
+        raise SystemExit(
+            f"No running tournament for {identifiers} (family={family}). "
+            "If a season just ended this may be correct, but check before ignoring it."
+        )
+    return resolved
 
 
 def _env_int(name: str, default: int) -> int:
@@ -431,15 +454,16 @@ if __name__ == "__main__":
                 raise SystemExit(
                     "No valid tournaments configured via --tournaments-file/--tournament."
                 )
+            tournaments = _resolve_tournaments(tournaments, family="market-pulse")
         else:
             market_pulse_env = os.getenv("MARKET_PULSE_TOURNAMENT", "").strip()
-            default_raw = market_pulse_env or client.CURRENT_MARKET_PULSE_ID
+            default_raw = market_pulse_env or "auto:market-pulse"
             default_id = extract_tournament_identifier(default_raw)
             if not default_id or default_id.startswith("index:"):
                 raise SystemExit(
                     "No tournament specified. Set MARKET_PULSE_TOURNAMENT or pass --tournament."
                 )
-            tournaments = [default_id]
+            tournaments = _resolve_tournaments([default_id], family="market-pulse")
 
         out_dir = Path("reports") / "retrospective"
         stamp = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -472,10 +496,10 @@ if __name__ == "__main__":
                 )
         else:
             market_pulse_env = os.getenv("MARKET_PULSE_TOURNAMENT", "").strip()
-            market_raw = market_pulse_env or client.CURRENT_MARKET_PULSE_ID
+            market_raw = market_pulse_env or "auto:market-pulse"
             market_id = extract_tournament_identifier(market_raw)
 
-            aib_raw = os.getenv("AIB_TOURNAMENT", "").strip() or client.CURRENT_AI_COMPETITION_ID
+            aib_raw = os.getenv("AIB_TOURNAMENT", "").strip() or "auto:futureeval"
             aib_id = extract_tournament_identifier(aib_raw)
 
             minibench_id = extract_tournament_identifier(client.CURRENT_MINIBENCH_ID)
@@ -486,11 +510,14 @@ if __name__ == "__main__":
             )
             cup_id = extract_tournament_identifier(cup_raw)
 
-            tournaments = [
-                t
-                for t in [market_id, aib_id, minibench_id, cup_id]
-                if t and not t.startswith("index:")
-            ]
+            tournaments = _resolve_tournaments(
+                [
+                    t
+                    for t in [market_id, aib_id, minibench_id, cup_id]
+                    if t and not t.startswith("index:")
+                ],
+                family="market-pulse",
+            )
             if not tournaments:
                 raise SystemExit(
                     "No tournaments configured for weekly_retrospective. Set MARKET_PULSE_TOURNAMENT/AIB_TOURNAMENT/METACULUS_CUP_TOURNAMENT or pass --tournament."
@@ -601,6 +628,7 @@ if __name__ == "__main__":
                     raise SystemExit(
                         "No valid tournaments configured via --tournaments-file/--tournament."
                     )
+                tournaments = _resolve_tournaments(tournaments, family="futureeval")
                 questions, scan_failures = _collect_open_questions_from_tournaments(
                     client=client,
                     tournaments=tournaments,
@@ -615,10 +643,12 @@ if __name__ == "__main__":
                         )
                     )
             else:
-                default_tournaments = [
-                    client.CURRENT_AI_COMPETITION_ID,
-                    client.CURRENT_MINIBENCH_ID,
-                ]
+                # The seasonal bot tournament is renamed every season and
+                # MiniBench restarts every two weeks; resolve both rather than
+                # trusting a constant that goes stale silently.
+                default_tournaments = _resolve_tournaments(
+                    ["auto:futureeval", "auto:minibench"], family="futureeval"
+                )
                 questions, scan_failures = _collect_open_questions_from_tournaments(
                     client=client,
                     tournaments=default_tournaments,
@@ -648,15 +678,16 @@ if __name__ == "__main__":
                     raise SystemExit(
                         "No valid tournaments configured via --tournaments-file/--tournament."
                     )
+                tournaments = _resolve_tournaments(tournaments, family="market-pulse")
             else:
                 market_pulse_env = os.getenv("MARKET_PULSE_TOURNAMENT", "").strip()
-                default_raw = market_pulse_env or client.CURRENT_MARKET_PULSE_ID
+                default_raw = market_pulse_env or "auto:market-pulse"
                 default_id = extract_tournament_identifier(default_raw)
                 if not default_id or default_id.startswith("index:"):
                     raise SystemExit(
                         "No tournament specified. Set MARKET_PULSE_TOURNAMENT or pass --tournament."
                     )
-                tournaments = [default_id]
+                tournaments = _resolve_tournaments([default_id], family="market-pulse")
 
             for tournament_id in tournaments:
                 questions_to_forecast, counts = select_questions_for_tournament_update(

--- a/tests/test_tournament_resolver.py
+++ b/tests/test_tournament_resolver.py
@@ -1,0 +1,165 @@
+import unittest
+from datetime import datetime, timezone
+
+import tournament_resolver as tr
+
+
+NOW = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+
+# Shapes taken from the real /api/projects/tournaments/ listing.
+LISTING = [
+    {
+        "slug": "market-pulse-26q2",
+        "type": "tournament",
+        "bot_leaderboard_status": "include",
+        "start_date": "2026-03-30T00:00:00Z",
+        "close_date": "2026-07-01T00:00:00Z",
+    },
+    {
+        "slug": "market-pulse-26q3",
+        "type": "tournament",
+        "bot_leaderboard_status": "include",
+        "start_date": "2026-07-08T21:00:00Z",
+        "close_date": "2026-10-01T00:00:00Z",
+    },
+    {
+        "slug": "summer-futureeval-2026",
+        "type": "tournament",
+        "bot_leaderboard_status": "bots_only",
+        "start_date": "2026-05-18T00:00:00Z",
+        "close_date": "2026-11-05T00:00:00Z",
+    },
+    {
+        "slug": "metaculus-cup-summer-2026",
+        "type": "tournament",
+        "bot_leaderboard_status": "exclude_and_show",
+        "start_date": "2026-05-04T00:00:00Z",
+        "close_date": "2026-09-04T00:00:00Z",
+    },
+    {
+        "slug": None,  # the listing really does contain these
+        "type": "question_series",
+        "bot_leaderboard_status": "exclude_and_show",
+        "start_date": None,
+        "close_date": None,
+    },
+]
+
+
+class TestResolveFamily(unittest.TestCase):
+    def test_market_pulse_picks_only_the_running_quarter(self) -> None:
+        self.assertEqual(
+            tr.resolve_family("market-pulse", now=NOW, listing=LISTING),
+            ["market-pulse-26q3"],
+        )
+
+    def test_seasonal_bot_tournament_matched_on_bots_only_not_on_name(self) -> None:
+        self.assertEqual(
+            tr.resolve_family("futureeval", now=NOW, listing=LISTING),
+            ["summer-futureeval-2026"],
+        )
+
+    def test_next_season_is_picked_up_without_any_config_change(self) -> None:
+        listing = LISTING + [
+            {
+                "slug": "fall-futureeval-2026",
+                "type": "tournament",
+                "bot_leaderboard_status": "bots_only",
+                "start_date": "2026-09-07T00:00:00Z",
+                "close_date": "2027-01-20T00:00:00Z",
+            }
+        ]
+        later = datetime(2026, 9, 20, 12, 0, tzinfo=timezone.utc)
+        # Summer closes 2026-11-05, so both are live: forecast on both.
+        self.assertEqual(
+            tr.resolve_family("futureeval", now=later, listing=listing),
+            ["summer-futureeval-2026", "fall-futureeval-2026"],
+        )
+
+    def test_overlapping_quarters_both_returned_oldest_first(self) -> None:
+        listing = LISTING + [
+            {
+                "slug": "market-pulse-26q4",
+                "type": "tournament",
+                "bot_leaderboard_status": "include",
+                "start_date": "2026-09-28T00:00:00Z",
+                "close_date": "2027-01-07T00:00:00Z",
+            }
+        ]
+        overlap = datetime(2026, 9, 29, 12, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            tr.resolve_family("market-pulse", now=overlap, listing=listing),
+            ["market-pulse-26q3", "market-pulse-26q4"],
+        )
+
+    def test_gap_between_quarters_returns_nothing_rather_than_guessing(self) -> None:
+        gap = datetime(2026, 10, 3, 12, 0, tzinfo=timezone.utc)  # q3 closed, q4 not up
+        self.assertEqual(tr.resolve_family("market-pulse", now=gap, listing=LISTING), [])
+
+    def test_minibench_slug_is_constant_and_needs_no_listing(self) -> None:
+        self.assertEqual(tr.resolve_family("minibench", now=NOW, listing=[]), ["minibench"])
+
+    def test_unknown_family_is_an_error_not_a_silent_empty(self) -> None:
+        with self.assertRaises(ValueError):
+            tr.resolve_family("no-such-family", now=NOW, listing=LISTING)
+
+
+class TestExpandIdentifiers(unittest.TestCase):
+    def test_auto_uses_the_default_family(self) -> None:
+        self.assertEqual(
+            tr.expand_identifiers(
+                ["auto"], default_family="market-pulse", now=NOW, listing=LISTING
+            ),
+            ["market-pulse-26q3"],
+        )
+
+    def test_auto_with_explicit_family_overrides_the_default(self) -> None:
+        self.assertEqual(
+            tr.expand_identifiers(
+                ["auto:futureeval"], default_family="market-pulse", now=NOW, listing=LISTING
+            ),
+            ["summer-futureeval-2026"],
+        )
+
+    def test_explicit_slugs_pass_through_untouched(self) -> None:
+        self.assertEqual(
+            tr.expand_identifiers(
+                ["market-pulse-26q1", "auto:minibench"],
+                default_family="market-pulse",
+                now=NOW,
+                listing=LISTING,
+            ),
+            ["market-pulse-26q1", "minibench"],
+        )
+
+    def test_duplicates_are_dropped_case_insensitively(self) -> None:
+        self.assertEqual(
+            tr.expand_identifiers(
+                ["auto", "Market-Pulse-26Q3"],
+                default_family="market-pulse",
+                now=NOW,
+                listing=LISTING,
+            ),
+            ["market-pulse-26q3"],
+        )
+
+    def test_mixed_auto_markers_resolve_together(self) -> None:
+        self.assertEqual(
+            tr.expand_identifiers(
+                ["auto:futureeval", "auto:minibench"],
+                default_family="futureeval",
+                now=NOW,
+                listing=LISTING,
+            ),
+            ["summer-futureeval-2026", "minibench"],
+        )
+
+    def test_is_auto_recognises_the_markers(self) -> None:
+        self.assertTrue(tr.is_auto("auto"))
+        self.assertTrue(tr.is_auto(" AUTO:market-pulse "))
+        self.assertFalse(tr.is_auto("market-pulse-26q3"))
+        self.assertFalse(tr.is_auto(""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tournament_resolver.py
+++ b/tournament_resolver.py
@@ -1,0 +1,191 @@
+"""Resolve which tournament to forecast on from the API, instead of a constant.
+
+Every Metaculus tournament slug is per-season. Market Pulse rotates quarterly
+(``market-pulse-26q3``), and the seasonal bot tournament has been called
+``aibq1``, ``fall-aib-2025``, ``spring-aib-2026`` and ``summer-futureeval-2026``
+in turn. Hard-coding any of them means the bot silently forecasts nothing the
+day the season turns: the run still exits 0, still logs, and just reports
+``total_open=0`` forever. That happened here for 149 days.
+
+Pass ``auto`` (or ``auto:<family>``) wherever a slug is expected and the
+currently running one is looked up instead.
+
+Deriving the slug from the calendar date does not work. The real windows are::
+
+    25q2  Apr 1  -> Jul 1        26q1  Dec 18 -> Apr 2
+    25q3  Jul 2  -> Oct 17       26q2  Mar 30 -> Jul 1
+    25q4  Sep 26 -> Jan 7        26q3  Jul 8  -> Oct 1
+
+Consecutive quarters overlap by about three weeks, and a quarter does not start
+on the first day of the calendar quarter. So this matches on the API's own
+start/close dates, and returns every tournament in the family that is currently
+inside its window -- during an overlap that is legitimately two of them.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Iterable, Sequence
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+TOURNAMENTS_URL = "https://www.metaculus.com/api/projects/tournaments/"
+AUTO_PATTERN = re.compile(r"^auto(?::(?P<family>[a-z0-9-]+))?$", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Family:
+    """How to recognise one recurring tournament series in the API listing."""
+
+    name: str
+    matches: Callable[[dict], bool]
+    # Slugs that are stable by design and may not appear in the public listing.
+    constant: tuple[str, ...] = ()
+
+
+def _is_market_pulse(item: dict) -> bool:
+    slug = item.get("slug")
+    return isinstance(slug, str) and slug.startswith("market-pulse-")
+
+
+def _is_seasonal_bot_tournament(item: dict) -> bool:
+    """The $50k seasonal bot tournament, whatever it is called this season.
+
+    Matched on ``bots_only`` rather than the name: the name has changed every
+    season, but a bots-only prize tournament is what it structurally is.
+    """
+    return (
+        item.get("bot_leaderboard_status") == "bots_only"
+        and item.get("type") == "tournament"
+    )
+
+
+FAMILIES: dict[str, Family] = {
+    "market-pulse": Family(name="market-pulse", matches=_is_market_pulse),
+    # MiniBench is unlisted, so it never shows up in the listing. Metaculus
+    # documents the slug as permanently "minibench": the currently active round
+    # always answers to it, so there is nothing to resolve.
+    "minibench": Family(name="minibench", matches=lambda _: False, constant=("minibench",)),
+    "futureeval": Family(name="futureeval", matches=_is_seasonal_bot_tournament),
+}
+
+
+def is_auto(value: str) -> bool:
+    return bool(AUTO_PATTERN.match((value or "").strip()))
+
+
+def _parse_dt(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _is_running(item: dict, now: datetime) -> bool:
+    start = _parse_dt(item.get("start_date"))
+    close = _parse_dt(item.get("close_date"))
+    if start and start > now:
+        return False
+    if close and close <= now:
+        return False
+    return True
+
+
+def fetch_tournaments(*, token: str | None = None, timeout: int = 30) -> list[dict]:
+    headers = {}
+    token = token or os.getenv("METACULUS_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Token {token}"
+    response = requests.get(TOURNAMENTS_URL, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict):
+        payload = payload.get("results", [])
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def resolve_family(
+    family_name: str,
+    *,
+    token: str | None = None,
+    now: datetime | None = None,
+    listing: Sequence[dict] | None = None,
+) -> list[str]:
+    """Slugs in ``family_name`` that are inside their own start/close window."""
+    family = FAMILIES.get(family_name)
+    if family is None:
+        raise ValueError(
+            f"Unknown tournament family {family_name!r}. "
+            f"Known: {', '.join(sorted(FAMILIES))}"
+        )
+    if family.constant:
+        return list(family.constant)
+
+    now = now or datetime.now(timezone.utc)
+    items = list(listing) if listing is not None else fetch_tournaments(token=token)
+    hits = []
+    for item in items:
+        slug = item.get("slug")
+        if not isinstance(slug, str) or not slug:
+            continue
+        if family.matches(item) and _is_running(item, now):
+            hits.append((_parse_dt(item.get("start_date")) or now, slug))
+    return [slug for _, slug in sorted(hits)]
+
+
+def expand_identifiers(
+    identifiers: Iterable[str],
+    *,
+    default_family: str,
+    token: str | None = None,
+    now: datetime | None = None,
+    listing: Sequence[dict] | None = None,
+) -> list[str]:
+    """Replace every ``auto`` / ``auto:<family>`` entry with the live slugs.
+
+    Anything that is not an auto marker is passed through untouched, so pinning
+    a specific slug still works exactly as before. Order is preserved and
+    duplicates are dropped.
+    """
+    resolved: list[str] = []
+    cached_listing = listing
+    for raw in identifiers:
+        match = AUTO_PATTERN.match((raw or "").strip())
+        if not match:
+            if raw:
+                resolved.append(raw)
+            continue
+        family = match.group("family") or default_family
+        if cached_listing is None and FAMILIES.get(family, Family("", lambda _: False)).constant == ():
+            try:
+                cached_listing = fetch_tournaments(token=token)
+            except Exception as exc:  # noqa: BLE001 - fall through to the error below
+                logger.error(f"Could not list tournaments to resolve {raw!r}: {exc!r}")
+                raise
+        found = resolve_family(family, token=token, now=now, listing=cached_listing)
+        if not found:
+            logger.warning(
+                f"No running tournament found for family {family!r} "
+                f"(from {raw!r}); nothing will be forecast for it."
+            )
+        else:
+            logger.info(f"Resolved {raw!r} -> {', '.join(found)}")
+        resolved.extend(found)
+
+    seen: set[str] = set()
+    unique = []
+    for slug in resolved:
+        key = str(slug).lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(slug)
+    return unique


### PR DESCRIPTION
## Why

Every Metaculus tournament slug is per-season, and hard-coding one means the bot silently forecasts nothing the day the season turns — the run still exits 0 and just logs `total_open=0`.

That already happened: the Market Pulse job ran against `market-pulse-26q1` for **149 consecutive days** (2026-04-02 onwards), exiting 0 every time. And `summer-futureeval-2026` — the fallback in the every-30-minutes tournament workflow — **stops accepting forecasts on 2026-09-06**, so the same failure was about to repeat.

The library defaults are stale too: `CURRENT_MARKET_PULSE_ID = 'market-pulse-26q1'`, `CURRENT_AI_COMPETITION_ID = 32916`.

## What

Pass `auto` (or `auto:<family>`) anywhere a slug is expected and the running tournament is looked up from `/api/projects/tournaments/`.

| family | how it is matched |
|---|---|
| `market-pulse` | slug prefix `market-pulse-`, inside its start/close window |
| `futureeval` | `bot_leaderboard_status == "bots_only"` + `type == "tournament"`, inside its window |
| `minibench` | constant — Metaculus documents the slug as permanently `minibench` (and it is unlisted, so it never appears in the listing) |

**Deriving the slug from the calendar date does not work.** The real windows are:

```
25q2  Apr 1  -> Jul 1        26q1  Dec 18 -> Apr 2
25q3  Jul 2  -> Oct 17       26q2  Mar 30 -> Jul 1
25q4  Sep 26 -> Jan 7        26q3  Jul 8  -> Oct 1
```

Consecutive quarters overlap by about three weeks (25q3 ran to Oct 17 while 25q4 opened Sep 26), and a quarter does not start on the first day of the calendar quarter (26q3 opened Jul 8). Date arithmetic would point at a slug that does not exist yet during the gap, and would miss the older tournament's closing waves during the overlap. So this matches on the API's own dates and returns *every* tournament in the family currently inside its window.

The seasonal bot tournament is matched on `bots_only` rather than on its name, because the name is the part that keeps changing: `aibq1` → `fall-aib-2025` → `spring-aib-2026` → `summer-futureeval-2026`.

## Compatibility

- Explicit slugs pass through untouched — pinning one for testing works exactly as before.
- `MARKET_PULSE_TOURNAMENT` / `BOT_TOURNAMENT` / `AIB_TOURNAMENT` still win when set; `auto` only replaces the hard-coded *fallback*.
- Failing to resolve is a `SystemExit`, not a silent skip — the whole lesson here is that quiet success is the dangerous failure mode.

## Testing

- 13 new unit tests: quarter rollover, overlapping quarters, the gap between quarters, unknown family, dedup, explicit-slug passthrough.
- Full suite: **88 tests, all passing**.
- Against the live API: `auto` → `market-pulse-26q3`, `auto:futureeval` → `summer-futureeval-2026`, `auto:minibench` → `minibench`.
- End to end: `--mode tournament_update`, `--mode tournament` (default path), and `--tournament auto` all resolve and run.